### PR TITLE
zig_ethp2p: broadcast engine, RS channel, and session skeleton

### DIFF
--- a/src/broadcast/channel_rs.zig
+++ b/src/broadcast/channel_rs.zig
@@ -1,0 +1,150 @@
+//! RS-only broadcast channel: members, sessions, publish (aligned with ethp2p `broadcast/channel.go`).
+
+const std = @import("std");
+const broadcast_types = @import("../layer/broadcast_types.zig");
+const rs_init = @import("../layer/rs_init.zig");
+const rs_strategy = @import("../layer/rs_strategy.zig");
+const Engine = @import("engine.zig").Engine;
+const SessionRs = @import("session_rs.zig").SessionRs;
+
+const Allocator = std.mem.Allocator;
+const RsConfig = rs_init.RsConfig;
+const RsStrategy = rs_strategy.RsStrategy;
+
+pub const ChannelRs = struct {
+    allocator: Allocator,
+    engine: *Engine,
+    id: []u8,
+    cfg: RsConfig,
+    members: std.ArrayListUnmanaged([]u8),
+    sessions: std.StringHashMapUnmanaged(*SessionRs),
+
+    pub fn init(allocator: Allocator, engine: *Engine, id: []u8, cfg: RsConfig) !ChannelRs {
+        return .{
+            .allocator = allocator,
+            .engine = engine,
+            .id = id,
+            .cfg = cfg,
+            .members = .{},
+            .sessions = .{},
+        };
+    }
+
+    pub fn deinit(self: *ChannelRs) void {
+        var sit = self.sessions.iterator();
+        while (sit.next()) |kv| {
+            const sess = kv.value_ptr.*;
+            sess.deinit();
+            self.allocator.destroy(sess);
+            self.allocator.free(kv.key_ptr.*);
+        }
+        self.sessions.deinit(self.allocator);
+        for (self.members.items) |m| self.allocator.free(m);
+        self.members.deinit(self.allocator);
+        self.allocator.free(self.id);
+    }
+
+    pub fn addMember(self: *ChannelRs, peer_id: []const u8) !void {
+        for (self.members.items) |m| {
+            if (std.mem.eql(u8, m, peer_id)) return;
+        }
+        const dup = try self.allocator.dupe(u8, peer_id);
+        errdefer self.allocator.free(dup);
+        try self.members.append(self.allocator, dup);
+    }
+
+    pub fn removeMember(self: *ChannelRs, peer_id: []const u8) void {
+        for (self.members.items, 0..) |m, i| {
+            if (std.mem.eql(u8, m, peer_id)) {
+                self.allocator.free(m);
+                _ = self.members.swapRemove(i);
+                return;
+            }
+        }
+    }
+
+    /// Origin session: encodes `payload` and attaches current members.
+    pub fn publish(self: *ChannelRs, message_id: []const u8, payload: []const u8) !void {
+        if (self.sessions.get(message_id) != null) return error.DuplicateMessage;
+
+        const mid = try self.allocator.dupe(u8, message_id);
+        errdefer self.allocator.free(mid);
+
+        var strat: ?RsStrategy = try RsStrategy.newOrigin(self.allocator, self.cfg, payload);
+        errdefer if (strat) |*s| s.deinit();
+
+        const n = self.members.items.len;
+        const member_ids = try self.allocator.alloc([]u8, n);
+        errdefer {
+            for (member_ids) |m| self.allocator.free(m);
+            self.allocator.free(member_ids);
+        }
+        const stats = try self.allocator.alloc(broadcast_types.PeerSessionStats, n);
+        errdefer self.allocator.free(stats);
+
+        for (0..n) |i| {
+            member_ids[i] = try self.allocator.dupe(u8, self.members.items[i]);
+            stats[i] = .{ .peer_id = member_ids[i] };
+            try strat.?.attachPeer(member_ids[i], &stats[i]);
+        }
+
+        const sess = try self.allocator.create(SessionRs);
+        errdefer {
+            sess.deinit();
+            self.allocator.destroy(sess);
+        }
+        sess.* = .{
+            .allocator = self.allocator,
+            .message_id = mid,
+            .strategy = strat.?,
+            .member_ids = member_ids,
+            .stats = stats,
+        };
+        strat = null;
+
+        try self.sessions.put(self.allocator, mid, sess);
+    }
+
+    pub fn sessionDrainOutbound(self: *ChannelRs, message_id: []const u8) !usize {
+        const slot = self.sessions.getPtr(message_id) orelse return error.UnknownMessage;
+        return slot.*.drainOutbound();
+    }
+
+    pub fn sessionDecode(self: *ChannelRs, message_id: []const u8) ![]u8 {
+        const slot = self.sessions.getPtr(message_id) orelse return error.UnknownMessage;
+        return slot.*.strategy.decode();
+    }
+
+    pub fn sessionStrategy(self: *ChannelRs, message_id: []const u8) ?*RsStrategy {
+        const slot = self.sessions.getPtr(message_id) orelse return null;
+        return &slot.*.strategy;
+    }
+};
+
+test "channel publish and drain to one member" {
+    const gpa = std.testing.allocator;
+    var eng = try Engine.init(gpa, "local", .{});
+    defer eng.deinit();
+
+    const cfg = RsConfig{
+        .data_shards = 4,
+        .parity_shards = 2,
+        .chunk_len = 0,
+        .bitmap_threshold = 0,
+        .forward_multiplier = 4,
+        .disable_bitmap = false,
+    };
+
+    const ch = try eng.attachChannelRs("topic", cfg);
+    try ch.addMember("p1");
+
+    const payload = [_]u8{ 'h', 'e', 'l', 'l', 'o' };
+    try ch.publish("m1", &payload);
+
+    const n = try ch.sessionDrainOutbound("m1");
+    try std.testing.expect(n > 0);
+
+    const decoded = try ch.sessionDecode("m1");
+    defer gpa.free(decoded);
+    try std.testing.expectEqualSlices(u8, &payload, decoded);
+}

--- a/src/broadcast/engine.zig
+++ b/src/broadcast/engine.zig
@@ -1,0 +1,55 @@
+//! Broadcast engine: owns channels keyed by id (aligned with ethp2p `broadcast/engine.go`).
+
+const std = @import("std");
+const ChannelRs = @import("channel_rs.zig").ChannelRs;
+const observer_mod = @import("observer.zig");
+
+const Allocator = std.mem.Allocator;
+
+pub const EngineConfig = struct {
+    observer: observer_mod.Observer = .{},
+};
+
+pub const Engine = struct {
+    allocator: Allocator,
+    local_peer_id: []u8,
+    config: EngineConfig,
+    channels: std.StringHashMapUnmanaged(*ChannelRs),
+
+    pub fn init(allocator: Allocator, local_peer_id: []const u8, config: EngineConfig) !Engine {
+        return .{
+            .allocator = allocator,
+            .local_peer_id = try allocator.dupe(u8, local_peer_id),
+            .config = config,
+            .channels = .{},
+        };
+    }
+
+    pub fn deinit(self: *Engine) void {
+        var it = self.channels.iterator();
+        while (it.next()) |kv| {
+            const ch = kv.value_ptr.*;
+            ch.deinit();
+            self.allocator.destroy(ch);
+        }
+        self.channels.deinit(self.allocator);
+        self.allocator.free(self.local_peer_id);
+    }
+
+    pub fn attachChannelRs(
+        self: *Engine,
+        channel_id: []const u8,
+        cfg: @import("../layer/rs_init.zig").RsConfig,
+    ) !*ChannelRs {
+        if (self.channels.get(channel_id) != null) return error.ChannelExists;
+        const key = try self.allocator.dupe(u8, channel_id);
+        errdefer self.allocator.free(key);
+        const ch = try self.allocator.create(ChannelRs);
+        errdefer self.allocator.destroy(ch);
+        ch.* = try ChannelRs.init(self.allocator, self, key, cfg);
+        try self.channels.put(self.allocator, key, ch);
+        return ch;
+    }
+};
+
+pub const Error = error{ChannelExists};

--- a/src/broadcast/observer.zig
+++ b/src/broadcast/observer.zig
@@ -1,0 +1,3 @@
+//! Optional hooks aligned with ethp2p `broadcast/observer` (placeholder for gossip integration).
+
+pub const Observer = struct {};

--- a/src/broadcast/session_rs.zig
+++ b/src/broadcast/session_rs.zig
@@ -1,0 +1,45 @@
+//! Per-message RS session: wraps `layer.rs_strategy.RsStrategy` for one broadcast message.
+
+const std = @import("std");
+const broadcast_types = @import("../layer/broadcast_types.zig");
+const rs_strategy = @import("../layer/rs_strategy.zig");
+
+const Allocator = std.mem.Allocator;
+const RsStrategy = rs_strategy.RsStrategy;
+
+pub const SessionRs = struct {
+    allocator: Allocator,
+    /// Owned by the parent `ChannelRs` map key; not freed here.
+    message_id: []const u8,
+    strategy: RsStrategy,
+    member_ids: [][]u8,
+    stats: []broadcast_types.PeerSessionStats,
+
+    pub fn deinit(self: *SessionRs) void {
+        self.strategy.deinit();
+        for (self.member_ids) |m| self.allocator.free(m);
+        self.allocator.free(self.member_ids);
+        self.allocator.free(self.stats);
+    }
+
+    /// One scheduling step: emit dispatches, then mark sends successful (simulates transport ACK).
+    pub fn pumpOnce(self: *SessionRs) !usize {
+        const out = try self.strategy.pollChunks();
+        defer self.allocator.free(out);
+        for (out) |disp| {
+            self.strategy.chunkSent(disp.peer, disp.chunk_id.handle(), true);
+        }
+        return out.len;
+    }
+
+    /// Run `pumpOnce` until no more chunks are scheduled.
+    pub fn drainOutbound(self: *SessionRs) !usize {
+        var total: usize = 0;
+        while (true) {
+            const n = try self.pumpOnce();
+            if (n == 0) break;
+            total += n;
+        }
+        return total;
+    }
+};

--- a/src/root.zig
+++ b/src/root.zig
@@ -18,8 +18,20 @@ pub const layer = struct {
     pub const rs_strategy = @import("layer/rs_strategy.zig");
 };
 
+/// Session / engine / RS channel stack aligned with ethp2p `broadcast/` (single-threaded `drive` style).
+pub const broadcast = struct {
+    pub const observer = @import("broadcast/observer.zig");
+    pub const engine = @import("broadcast/engine.zig");
+    pub const channel_rs = @import("broadcast/channel_rs.zig");
+    pub const session_rs = @import("broadcast/session_rs.zig");
+};
+
 test {
     _ = wire;
     _ = layer;
     _ = sim.rs_mesh;
+    _ = broadcast.engine;
+    _ = broadcast.channel_rs;
+    _ = broadcast.session_rs;
+    _ = broadcast.observer;
 }


### PR DESCRIPTION
## Summary

Adds a minimal single-threaded broadcast stack aligned with ethp2p `broadcast/` (engine, RS-only channel, per-message session).

- **Engine**: owns local peer id, registers RS channels by string id (`attachChannelRs`).
- **ChannelRs**: members, `publish` (origin `RsStrategy` + `attachPeer` per member), session map keyed by message id.
- **SessionRs**: `pumpOnce` / `drainOutbound` via `pollChunks` + `chunkSent` (same scheduling pattern as `sim/rs_mesh`).
- **Observer**: empty placeholder for future hooks.
- **Test**: publish + drain to one member + decode roundtrip.

## Checklist

- [x] `zig build test` passes (32 tests).

## Follow-ups (later branches)

- gossipsub-transport / protocol-core / broadcast-integration per roadmap.