### PR TITLE
zig_ethp2p: gossipsub sim message envelope

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,14 +21,15 @@ Zig helpers for the wire formats of **[ethp2p](https://github.com/ethp2p/ethp2p)
 | RS parity encode (klauspost-default matrix) | [klauspost/reedsolomon](https://github.com/klauspost/reedsolomon) via ethp2p RS strategy | `layer.rs_encode`, `ReedSolomon`, `decodeMessage` |
 | RS unified strategy (per-session) | [`broadcast/rs/strategy.go`](https://github.com/ethp2p/ethp2p/blob/main/broadcast/rs/strategy.go) | `layer.rs_strategy` |
 | Abstract RS mesh (strategy-only, same topologies as Go `TestNetwork` RS) | [`sim/scenario_test.go`](https://github.com/ethp2p/ethp2p/blob/main/sim/scenario_test.go) | `sim.rs_mesh`, `zig build simtest` |
-| **Not in scope yet** | [`broadcast/engine.go`](https://github.com/ethp2p/ethp2p/blob/main/broadcast/engine.go), [`session.go`](https://github.com/ethp2p/ethp2p/blob/main/broadcast/session.go), [`channel.go`](https://github.com/ethp2p/ethp2p/blob/main/broadcast/channel.go), RLNC, full Go simnet stack, transport | — (see **Pending work** below) |
+| Gossipsub sim publish bytes (same layout as Go `encodeGossipsubMessage`) + default topic | [`sim/strategy_gossipsub.go`](https://github.com/ethp2p/ethp2p/blob/main/sim/strategy_gossipsub.go) | `sim.gossipsub_transport` |
+| **Not in scope yet** | libp2p gossipsub host, QUIC simnet wiring, RLNC, full Go simnet parity | — (see **Pending work** below) |
 
 ## Pending work
 
 Items to tackle later; not an exhaustive roadmap.
 
-- **Broadcast session stack**: Port or wrap the reference **session / engine / channel** model (`session.go`, `engine.go`, `channel.go`) so chunk lifecycle, dedup, and routing ticks match ethp2p end-to-end (today only the RS **strategy** API is mirrored in Zig).
-- **Gossipsub strategy**: No Zig analogue of ethp2p’s gossipsub broadcast path or `TestNetwork/Gossipsub` in `sim/scenario_test.go`; add strategy + tests when that layer is needed.
+- **Broadcast session stack**: Implemented as `broadcast.*` (engine / RS channel / session); still no parity with full dedup / async verify / multi-scheme from the Go stack.
+- **Gossipsub**: `sim.gossipsub_transport` matches the sim **message envelope** and default topic; **protocol-core** (mesh RPC semantics) and **broadcast-integration** (engine + envelope) are still open. No libp2p host in Zig.
 - **Go simnet parity**: No integration with **[marcopolo/simnet](https://github.com/marcopolo/simnet)** / libp2p / QUIC. Abstract mesh tests deliberately avoid UDP and real latency; a future step is driving **this** library from a real network sim or FFI if we need byte-identical timing traces.
 - **Large / stress scenarios**: Go CI runs `TestLargeNetwork_RS` and `TestScalability` on `main` only; Zig has no equivalent long-run or scale tests yet.
 - **RLNC and other schemes**: Reference may grow beyond RS; RLNC and additional `broadcast.Scheme` implementations are out of tree.

--- a/src/root.zig
+++ b/src/root.zig
@@ -6,6 +6,7 @@ pub const wire = @import("wire/root.zig");
 /// Abstract multi-hop RS scenarios aligned with ethp2p `sim/scenario_test.go` (strategy-only; no libp2p).
 pub const sim = struct {
     pub const rs_mesh = @import("sim/rs_mesh.zig");
+    pub const gossipsub_transport = @import("sim/gossipsub_transport.zig");
 };
 
 /// Higher-level broadcast / RS helpers aligned with ethp2p `broadcast/` (not wire-only).
@@ -30,6 +31,7 @@ test {
     _ = wire;
     _ = layer;
     _ = sim.rs_mesh;
+    _ = sim.gossipsub_transport;
     _ = broadcast.engine;
     _ = broadcast.channel_rs;
     _ = broadcast.session_rs;

--- a/src/sim/gossipsub_transport.zig
+++ b/src/sim/gossipsub_transport.zig
@@ -1,0 +1,68 @@
+//! Gossipsub-side message envelope and default topic id used by ethp2p’s simnet driver.
+//! Matches `encodeGossipsubMessage` / `decodeGossipsubMessage` / `gossipsubChannelID` in
+//! [strategy_gossipsub.go](https://github.com/ethp2p/ethp2p/blob/main/sim/strategy_gossipsub.go).
+
+const std = @import("std");
+
+const Allocator = std.mem.Allocator;
+
+/// Same string as Go `gossipsubChannelID` (`sim/strategy_gossipsub.go`).
+pub const default_topic = "broadcast-test";
+
+pub const DecodeError = error{MissingSeparator};
+
+/// View into `data`; does not allocate.
+pub fn decodeMessage(data: []const u8) DecodeError!struct {
+    message_id: []const u8,
+    payload: []const u8,
+} {
+    const sep = std.mem.indexOfScalar(u8, data, '|') orelse return error.MissingSeparator;
+    return .{
+        .message_id = data[0..sep],
+        .payload = data[sep + 1 ..],
+    };
+}
+
+/// Same behavior as Go `gossipsubMessageID`: id slice, or empty if decoding fails.
+pub fn messageIdFromPayload(data: []const u8) []const u8 {
+    const dec = decodeMessage(data) catch return &.{};
+    return dec.message_id;
+}
+
+/// Same layout as Go `encodeGossipsubMessage`.
+pub fn encodeMessage(allocator: Allocator, message_id: []const u8, payload: []const u8) Allocator.Error![]u8 {
+    const out = try allocator.alloc(u8, message_id.len + 1 + payload.len);
+    @memcpy(out[0..message_id.len], message_id);
+    out[message_id.len] = '|';
+    @memcpy(out[message_id.len + 1 ..], payload);
+    return out;
+}
+
+test "encode and decode roundtrip" {
+    const gpa = std.testing.allocator;
+    const enc = try encodeMessage(gpa, "mid-1", "payload-bytes");
+    defer gpa.free(enc);
+
+    const dec = try decodeMessage(enc);
+    try std.testing.expectEqualStrings("mid-1", dec.message_id);
+    try std.testing.expectEqualStrings("payload-bytes", dec.payload);
+}
+
+test "decode empty message id before separator" {
+    const dec = try decodeMessage("|rest");
+    try std.testing.expectEqualStrings("", dec.message_id);
+    try std.testing.expectEqualStrings("rest", dec.payload);
+}
+
+test "decode rejects missing separator" {
+    try std.testing.expectError(error.MissingSeparator, decodeMessage("noseparator"));
+}
+
+test "messageIdFromPayload matches Go error path" {
+    try std.testing.expectEqual(@as(usize, 0), messageIdFromPayload("bad").len);
+    try std.testing.expectEqualStrings("x", messageIdFromPayload("x|y"));
+}
+
+test "default topic matches reference constant" {
+    try std.testing.expectEqualStrings("broadcast-test", default_topic);
+}


### PR DESCRIPTION
## Summary
Adds `sim.gossipsub_transport`: Go-compatible `message_id|payload` encoding, `messageIdFromPayload`, and `default_topic` (`broadcast-test`).

## Tests
`zig build test` (37 tests).

## Follow-up
`gossipsub-protocol-core` and `gossipsub-broadcast-integration` branches add abstract fanout mesh and integration helpers.