### PR TITLE
zig_ethp2p: gossipsub abstract fanout mesh (protocol core)

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,14 +22,15 @@ Zig helpers for the wire formats of **[ethp2p](https://github.com/ethp2p/ethp2p)
 | RS unified strategy (per-session) | [`broadcast/rs/strategy.go`](https://github.com/ethp2p/ethp2p/blob/main/broadcast/rs/strategy.go) | `layer.rs_strategy` |
 | Abstract RS mesh (strategy-only, same topologies as Go `TestNetwork` RS) | [`sim/scenario_test.go`](https://github.com/ethp2p/ethp2p/blob/main/sim/scenario_test.go) | `sim.rs_mesh`, `zig build simtest` |
 | Gossipsub sim publish bytes (same layout as Go `encodeGossipsubMessage`) + default topic | [`sim/strategy_gossipsub.go`](https://github.com/ethp2p/ethp2p/blob/main/sim/strategy_gossipsub.go) | `sim.gossipsub_transport` |
-| **Not in scope yet** | libp2p gossipsub host, QUIC simnet wiring, RLNC, full Go simnet parity | — (see **Pending work** below) |
+| Abstract topic fanout + per-peer inboxes (no protobuf RPC) | same driver `Publish` / subscribe mesh | `sim.gossipsub_protocol` |
+| **Not in scope yet** | libp2p gossipsub host, QUIC simnet wiring, gossipsub protobuf RPC, encode+fanout helper PR, RLNC | — (see **Pending work** below) |
 
 ## Pending work
 
 Items to tackle later; not an exhaustive roadmap.
 
 - **Broadcast session stack**: Implemented as `broadcast.*` (engine / RS channel / session); still no parity with full dedup / async verify / multi-scheme from the Go stack.
-- **Gossipsub**: `sim.gossipsub_transport` matches the sim **message envelope** and default topic; **protocol-core** (mesh RPC semantics) and **broadcast-integration** (engine + envelope) are still open. No libp2p host in Zig.
+- **Gossipsub**: `sim.gossipsub_transport` (envelope), `sim.gossipsub_protocol` (abstract fanout mesh). Integration helpers (`encodeAndFanout`, `broadcast.gossip`) land in the next PR. No libp2p host, no IHAVE/IWANT **wire** parity with `go-libp2p-pubsub` protobuf.
 - **Go simnet parity**: No integration with **[marcopolo/simnet](https://github.com/marcopolo/simnet)** / libp2p / QUIC. Abstract mesh tests deliberately avoid UDP and real latency; a future step is driving **this** library from a real network sim or FFI if we need byte-identical timing traces.
 - **Large / stress scenarios**: Go CI runs `TestLargeNetwork_RS` and `TestScalability` on `main` only; Zig has no equivalent long-run or scale tests yet.
 - **RLNC and other schemes**: Reference may grow beyond RS; RLNC and additional `broadcast.Scheme` implementations are out of tree.

--- a/src/root.zig
+++ b/src/root.zig
@@ -7,6 +7,7 @@ pub const wire = @import("wire/root.zig");
 pub const sim = struct {
     pub const rs_mesh = @import("sim/rs_mesh.zig");
     pub const gossipsub_transport = @import("sim/gossipsub_transport.zig");
+    pub const gossipsub_protocol = @import("sim/gossipsub_protocol.zig");
 };
 
 /// Higher-level broadcast / RS helpers aligned with ethp2p `broadcast/` (not wire-only).
@@ -32,6 +33,7 @@ test {
     _ = layer;
     _ = sim.rs_mesh;
     _ = sim.gossipsub_transport;
+    _ = sim.gossipsub_protocol;
     _ = broadcast.engine;
     _ = broadcast.channel_rs;
     _ = broadcast.session_rs;

--- a/src/sim/gossipsub_protocol.zig
+++ b/src/sim/gossipsub_protocol.zig
@@ -1,0 +1,114 @@
+//! Abstract topic fanout and per-peer inboxes (no libp2p, no protobuf RPC).
+//! Models “subscribed peers receive opaque gossip payloads” as in ethp2p’s
+//! [`GossipsubNode.Publish`](https://github.com/ethp2p/ethp2p/blob/main/sim/strategy_gossipsub.go).
+//! Full gossipsub IHAVE/IWANT **wire** formats are still out of scope.
+
+const std = @import("std");
+
+const Allocator = std.mem.Allocator;
+
+pub const FanoutMesh = struct {
+    allocator: Allocator,
+    /// Topic string (owned key) → subscriber peer ids (each id owned).
+    subscriptions: std.StringHashMapUnmanaged(std.ArrayListUnmanaged([]u8)),
+    /// Peer id (owned key) → queued gossip blobs (each blob owned).
+    inboxes: std.StringHashMapUnmanaged(std.ArrayListUnmanaged([]u8)),
+
+    pub fn init(allocator: Allocator) FanoutMesh {
+        return .{
+            .allocator = allocator,
+            .subscriptions = .{},
+            .inboxes = .{},
+        };
+    }
+
+    pub fn deinit(self: *FanoutMesh) void {
+        var sub_it = self.subscriptions.iterator();
+        while (sub_it.next()) |kv| {
+            self.allocator.free(kv.key_ptr.*);
+            for (kv.value_ptr.items) |p| self.allocator.free(p);
+            kv.value_ptr.deinit(self.allocator);
+        }
+        self.subscriptions.deinit(self.allocator);
+
+        var in_it = self.inboxes.iterator();
+        while (in_it.next()) |kv| {
+            self.allocator.free(kv.key_ptr.*);
+            for (kv.value_ptr.items) |b| self.allocator.free(b);
+            kv.value_ptr.deinit(self.allocator);
+        }
+        self.inboxes.deinit(self.allocator);
+    }
+
+    /// Register interest in `topic`. `peer_id` is copied.
+    pub fn subscribe(self: *FanoutMesh, peer_id: []const u8, topic: []const u8) Allocator.Error!void {
+        const peer_dup = try self.allocator.dupe(u8, peer_id);
+        errdefer self.allocator.free(peer_dup);
+
+        const t_gop = try self.subscriptions.getOrPut(self.allocator, topic);
+        if (!t_gop.found_existing) {
+            t_gop.key_ptr.* = try self.allocator.dupe(u8, topic);
+            t_gop.value_ptr.* = .{};
+        }
+
+        for (t_gop.value_ptr.items) |p| {
+            if (std.mem.eql(u8, p, peer_dup)) {
+                self.allocator.free(peer_dup);
+                return;
+            }
+        }
+        try t_gop.value_ptr.append(self.allocator, peer_dup);
+    }
+
+    /// Deliver a copy of `data` to every subscriber of `topic` except `from` (e.g. publisher peer id).
+    pub fn publishData(self: *FanoutMesh, from: []const u8, topic: []const u8, data: []const u8) Allocator.Error!void {
+        const subs = self.subscriptions.get(topic) orelse return;
+        for (subs.items) |peer| {
+            if (std.mem.eql(u8, peer, from)) continue;
+            const blob = try self.allocator.dupe(u8, data);
+            errdefer self.allocator.free(blob);
+
+            const i_gop = try self.inboxes.getOrPut(self.allocator, peer);
+            if (!i_gop.found_existing) {
+                i_gop.key_ptr.* = try self.allocator.dupe(u8, peer);
+                i_gop.value_ptr.* = .{};
+            }
+            try i_gop.value_ptr.append(self.allocator, blob);
+        }
+    }
+
+    /// Moves all queued blobs for `peer_id` into `out`. Caller frees each `[]u8` and clears `out` when done.
+    pub fn drainPeer(self: *FanoutMesh, peer_id: []const u8, out: *std.ArrayListUnmanaged([]u8)) Allocator.Error!void {
+        const ent = self.inboxes.fetchRemove(peer_id) orelse return;
+        defer self.allocator.free(ent.key);
+        var list = ent.value;
+        defer list.deinit(self.allocator);
+        try out.appendSlice(self.allocator, list.items);
+    }
+};
+
+test "fanout delivers to subscribers except publisher" {
+    const gpa = std.testing.allocator;
+    var mesh = FanoutMesh.init(gpa);
+    defer mesh.deinit();
+
+    const topic = "broadcast-test";
+    try mesh.subscribe("alice", topic);
+    try mesh.subscribe("bob", topic);
+
+    try mesh.publishData("alice", topic, "hello");
+
+    var bob_inbox: std.ArrayListUnmanaged([]u8) = .{};
+    defer {
+        for (bob_inbox.items) |s| gpa.free(s);
+        bob_inbox.deinit(gpa);
+    }
+    try mesh.drainPeer("bob", &bob_inbox);
+    try std.testing.expectEqual(@as(usize, 1), bob_inbox.items.len);
+    try std.testing.expectEqualStrings("hello", bob_inbox.items[0]);
+
+    var alice_inbox: std.ArrayListUnmanaged([]u8) = .{};
+    defer alice_inbox.deinit(gpa);
+    try mesh.drainPeer("alice", &alice_inbox);
+    try std.testing.expectEqual(@as(usize, 0), alice_inbox.items.len);
+}


### PR DESCRIPTION
## Summary
Adds `sim.gossipsub_protocol.FanoutMesh`: topic subscriptions, `publishData` to all subscribers except the publisher, `drainPeer` for queued opaque blobs.

Abstract only: no libp2p protobuf RPC (IHAVE/IWANT wire).

## Depends on
- #3 (`gossipsub-transport`)

## Tests
`zig build test` (38 tests on this branch tip).