### PR TITLE
zig_ethp2p: gossipsub encode+fanout and broadcast.gossip

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,14 +23,16 @@ Zig helpers for the wire formats of **[ethp2p](https://github.com/ethp2p/ethp2p)
 | Abstract RS mesh (strategy-only, same topologies as Go `TestNetwork` RS) | [`sim/scenario_test.go`](https://github.com/ethp2p/ethp2p/blob/main/sim/scenario_test.go) | `sim.rs_mesh`, `zig build simtest` |
 | Gossipsub sim publish bytes (same layout as Go `encodeGossipsubMessage`) + default topic | [`sim/strategy_gossipsub.go`](https://github.com/ethp2p/ethp2p/blob/main/sim/strategy_gossipsub.go) | `sim.gossipsub_transport` |
 | Abstract topic fanout + per-peer inboxes (no protobuf RPC) | same driver `Publish` / subscribe mesh | `sim.gossipsub_protocol` |
-| **Not in scope yet** | libp2p gossipsub host, QUIC simnet wiring, gossipsub protobuf RPC, encode+fanout helper PR, RLNC | — (see **Pending work** below) |
+| Encode + fanout helper | `GossipsubNode.Publish` + topic delivery | `sim.gossipsub_broadcast` |
+| App payload envelope entry point (re-export) | `encodeGossipsubMessage` | `broadcast.gossip` |
+| **Not in scope yet** | libp2p gossipsub host, QUIC simnet wiring, gossipsub protobuf RPC, RLNC | — (see **Pending work** below) |
 
 ## Pending work
 
 Items to tackle later; not an exhaustive roadmap.
 
 - **Broadcast session stack**: Implemented as `broadcast.*` (engine / RS channel / session); still no parity with full dedup / async verify / multi-scheme from the Go stack.
-- **Gossipsub**: `sim.gossipsub_transport` (envelope), `sim.gossipsub_protocol` (abstract fanout mesh). Integration helpers (`encodeAndFanout`, `broadcast.gossip`) land in the next PR. No libp2p host, no IHAVE/IWANT **wire** parity with `go-libp2p-pubsub` protobuf.
+- **Gossipsub**: `sim.gossipsub_transport` (envelope), `sim.gossipsub_protocol` (abstract fanout mesh), `sim.gossipsub_broadcast` + `broadcast.gossip` (helpers). No libp2p host, no IHAVE/IWANT **wire** parity with `go-libp2p-pubsub` protobuf.
 - **Go simnet parity**: No integration with **[marcopolo/simnet](https://github.com/marcopolo/simnet)** / libp2p / QUIC. Abstract mesh tests deliberately avoid UDP and real latency; a future step is driving **this** library from a real network sim or FFI if we need byte-identical timing traces.
 - **Large / stress scenarios**: Go CI runs `TestLargeNetwork_RS` and `TestScalability` on `main` only; Zig has no equivalent long-run or scale tests yet.
 - **RLNC and other schemes**: Reference may grow beyond RS; RLNC and additional `broadcast.Scheme` implementations are out of tree.

--- a/src/broadcast/gossip.zig
+++ b/src/broadcast/gossip.zig
@@ -1,0 +1,12 @@
+//! Gossipsub **sim** publish envelope for raw application payloads (not RS chunk streams).
+//! RS broadcast uses `wire.*` and `layer.rs_strategy`; this module is the same shape as Go
+//! `encodeGossipsubMessage` for app-level bytes.
+
+const std = @import("std");
+const gossipsub_transport = @import("../sim/gossipsub_transport.zig");
+
+pub const default_topic = gossipsub_transport.default_topic;
+
+pub fn encodeApplicationPublish(allocator: std.mem.Allocator, message_id: []const u8, payload: []const u8) ![]u8 {
+    return gossipsub_transport.encodeMessage(allocator, message_id, payload);
+}

--- a/src/root.zig
+++ b/src/root.zig
@@ -8,6 +8,7 @@ pub const sim = struct {
     pub const rs_mesh = @import("sim/rs_mesh.zig");
     pub const gossipsub_transport = @import("sim/gossipsub_transport.zig");
     pub const gossipsub_protocol = @import("sim/gossipsub_protocol.zig");
+    pub const gossipsub_broadcast = @import("sim/gossipsub_broadcast.zig");
 };
 
 /// Higher-level broadcast / RS helpers aligned with ethp2p `broadcast/` (not wire-only).
@@ -26,6 +27,7 @@ pub const broadcast = struct {
     pub const engine = @import("broadcast/engine.zig");
     pub const channel_rs = @import("broadcast/channel_rs.zig");
     pub const session_rs = @import("broadcast/session_rs.zig");
+    pub const gossip = @import("broadcast/gossip.zig");
 };
 
 test {
@@ -34,8 +36,10 @@ test {
     _ = sim.rs_mesh;
     _ = sim.gossipsub_transport;
     _ = sim.gossipsub_protocol;
+    _ = sim.gossipsub_broadcast;
     _ = broadcast.engine;
     _ = broadcast.channel_rs;
     _ = broadcast.session_rs;
     _ = broadcast.observer;
+    _ = broadcast.gossip;
 }

--- a/src/sim/gossipsub_broadcast.zig
+++ b/src/sim/gossipsub_broadcast.zig
@@ -1,0 +1,54 @@
+//! Helpers tying `gossipsub_transport` framing to `FanoutMesh` delivery (abstract sim path).
+
+const std = @import("std");
+const gossipsub_protocol = @import("gossipsub_protocol.zig");
+const gossipsub_transport = @import("gossipsub_transport.zig");
+
+const Allocator = std.mem.Allocator;
+pub const FanoutMesh = gossipsub_protocol.FanoutMesh;
+
+/// Encode like Go `GossipsubNode.Publish`, then fan out opaque bytes to topic subscribers (except `from`).
+pub fn encodeAndFanout(
+    mesh: *FanoutMesh,
+    allocator: Allocator,
+    from: []const u8,
+    topic: []const u8,
+    message_id: []const u8,
+    payload: []const u8,
+) Allocator.Error!void {
+    const enc = try gossipsub_transport.encodeMessage(allocator, message_id, payload);
+    defer allocator.free(enc);
+    try mesh.publishData(from, topic, enc);
+}
+
+test "encodeAndFanout roundtrip through mesh" {
+    const gpa = std.testing.allocator;
+    var mesh = FanoutMesh.init(gpa);
+    defer mesh.deinit();
+
+    const topic = gossipsub_transport.default_topic;
+    try mesh.subscribe("alice", topic);
+    try mesh.subscribe("bob", topic);
+
+    const app = [_]u8{ 1, 2, 3, 4 };
+    try encodeAndFanout(&mesh, gpa, "alice", topic, "mid-z", &app);
+
+    var bob_inbox: std.ArrayListUnmanaged([]u8) = .{};
+    defer {
+        for (bob_inbox.items) |s| gpa.free(s);
+        bob_inbox.deinit(gpa);
+    }
+    try mesh.drainPeer("bob", &bob_inbox);
+    try std.testing.expectEqual(@as(usize, 1), bob_inbox.items.len);
+
+    const dec = try gossipsub_transport.decodeMessage(bob_inbox.items[0]);
+    try std.testing.expectEqualStrings("mid-z", dec.message_id);
+    try std.testing.expectEqualSlices(u8, &app, dec.payload);
+}
+
+test "golden sim publish bytes" {
+    const gpa = std.testing.allocator;
+    const enc = try gossipsub_transport.encodeMessage(gpa, "m", "p");
+    defer gpa.free(enc);
+    try std.testing.expectEqualSlices(u8, &.{ 'm', '|', 'p' }, enc);
+}


### PR DESCRIPTION
## Summary
- `sim.gossipsub_broadcast`: `encodeAndFanout`, tests (mesh roundtrip + golden bytes).
- `broadcast.gossip`: `encodeApplicationPublish` + `default_topic` re-export.

## Depends on
Stacked PR after `gossipsub-protocol-core` merges (or merge this branch after that one).

## Tests
`zig build test` (40 tests).