### PR TITLE
zig_ethp2p: TestLargeNetwork_RS-scale topologies

### DIFF
--- a/src/sim/rs_mesh.zig
+++ b/src/sim/rs_mesh.zig
@@ -301,7 +301,7 @@ test "abstract RS mesh six nodes env stress (ZIG_ETHP2P_STRESS=1)" {
     });
 }
 
-/// Larger graph than default six-node `TestNetwork` topology 1; only with `ZIG_ETHP2P_STRESS=1`.
+// Larger graph than default six-node TestNetwork topology 1; only with ZIG_ETHP2P_STRESS=1.
 test "abstract RS mesh eight nodes ring env stress (large-network scale)" {
     const builtin = @import("builtin");
     if (builtin.os.tag == .windows) return;


### PR DESCRIPTION
**Implemented:** `topo_eight_ring` (8 nodes) + test `abstract RS mesh eight nodes ring env stress (large-network scale)` — runs only when `ZIG_ETHP2P_STRESS=1` (same pattern as the existing six-node stress case), `max_rounds = 8_000_000`.

This extends abstract RS mesh coverage toward Go `TestLargeNetwork_RS` / scalability-style graphs without slowing default CI. Merge `main` is included on this branch.