### PR TITLE
zig_ethp2p: multi-peer dedup registry and verify workers

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,10 @@ Zig helpers for the wire formats of **[ethp2p](https://github.com/ethp2p/ethp2p)
 | Protocol version constant | [`broadcast/types.go`](https://github.com/ethp2p/ethp2p/blob/main/broadcast/types.go) `ProtocolV1` | `wire.constants.protocol_v1` |
 | `Verdict` / `ChunkHandle` | [`broadcast/types.go`](https://github.com/ethp2p/ethp2p/blob/main/broadcast/types.go) | `layer.broadcast_types` |
 | `DedupCancel` + `DedupGroup` token (session hook) | session → strategy `takeChunk` | `layer.broadcast_types`, `layer.dedup` |
+| Engine-wide dedup registry (`channel` + `message` + chunk index) | multi-peer ingest dedup | `layer.dedup_registry`, `Engine.enable_cross_session_dedup` |
 | Verify result FIFO (single-threaded `Verified()` shim) | async verify channels | `layer.verify_queue` |
+| Verify worker pool (SHA256 vs preamble hash → queue) | background verify workers | `layer.verify_workers` |
+| Relay session attach + `relayIngestChunk` | relay ingest path | `broadcast.channel_rs` |
 | RS routing bitmap | [`broadcast/rs/bitmap.go`](https://github.com/ethp2p/ethp2p/blob/main/broadcast/rs/bitmap.go) | `layer.bitmap` |
 | RS `Config` / `initPreamble` | [`broadcast/rs/types.go`](https://github.com/ethp2p/ethp2p/blob/main/broadcast/rs/types.go) | `layer.rs_init` |
 | RS emit planner (fair dispatch heap) | [`broadcast/rs/emit.go`](https://github.com/ethp2p/ethp2p/blob/main/broadcast/rs/emit.go) | `layer.emit_planner` |
@@ -29,15 +32,15 @@ Zig helpers for the wire formats of **[ethp2p](https://github.com/ethp2p/ethp2p)
 | App payload envelope entry point (re-export) | `encodeGossipsubMessage` | `broadcast.gossip` |
 | Gossipsim cross-checks (golden envelope, mesh fanout, `broadcast.gossip` vs transport) | — | `sim.gossipsub_interop` |
 | Gossipsub `ControlIHave` / `ControlIWant` protobuf bodies (subset of [libp2p `rpc.proto`](https://github.com/libp2p/go-libp2p-pubsub/blob/master/pb/rpc.proto)) | `ControlMessage` nested fields | `sim.gossipsub_rpc_pb`, `proto/gossipsub_rpc.proto` |
-| **Not in scope yet** | Full `RPC` / stream framing for libp2p, QUIC simnet host, RLNC, true async verify goroutines | — (see **Pending work** below) |
+| **Not in scope yet** | Full `RPC` / stream framing for libp2p, QUIC simnet host, RLNC, Go-parity verify pipeline wiring | — (see **Pending work** below) |
 
 ## Pending work
 
-What is **in tree today**: wire + layer RS strategy, `layer.dedup` / `layer.verify_queue`, `broadcast.*` (engine / RS channel / session / `gossip`), abstract RS mesh (2-, 4-, 6-node + optional **stress**), gossipsim stack, and **hand-written** encode/decode for gossipsub `ControlIHave` / `ControlIWant` message bodies (`sim.gossipsub_rpc_pb`). Default `zig build test` stays fast.
+What is **in tree today**: wire + layer RS strategy, `layer.dedup` / `layer.dedup_registry` / `layer.verify_queue` / `layer.verify_workers`, `broadcast.*` (engine / RS channel / session / `gossip`, relay ingest helpers), abstract RS mesh (2-, 4-, 6-node + optional **stress**), gossipsim stack, and **hand-written** encode/decode for gossipsub `ControlIHave` / `ControlIWant` message bodies (`sim.gossipsub_rpc_pb`). Default `zig build test` stays fast.
 
 What is **still open** (not exhaustive):
 
-- **Broadcast parity with Go**: No full multi-peer dedup **registry**, background verify workers, or RLNC / extra `Scheme` types.
+- **Broadcast parity with Go**: Dedup registry + verify pool are library primitives; no full session/registry wiring like production Go yet. RLNC / extra `Scheme` types still out.
 - **Real gossipsub / simnet**: No **[marcopolo/simnet](https://github.com/marcopolo/simnet)** or libp2p host; no full `RPC` protobuf framing on the wire.
 - **Huge RS scenarios**: Go’s `TestLargeNetwork_RS` / `TestScalability` scale is not mirrored; use `zig build test-stress` (sets `ZIG_ETHP2P_STRESS=1`) for an extra 6-node mesh budget, or raise rounds locally.
 - **RLNC and other EC schemes**: Out of tree until needed.

--- a/src/broadcast/channel_rs.zig
+++ b/src/broadcast/channel_rs.zig
@@ -2,6 +2,8 @@
 
 const std = @import("std");
 const broadcast_types = @import("../layer/broadcast_types.zig");
+const dedup_mod = @import("../layer/dedup.zig");
+const dedup_registry_mod = @import("../layer/dedup_registry.zig");
 const rs_init = @import("../layer/rs_init.zig");
 const rs_strategy = @import("../layer/rs_strategy.zig");
 const Engine = @import("engine.zig").Engine;
@@ -105,6 +107,47 @@ pub const ChannelRs = struct {
         try self.sessions.put(self.allocator, mid, sess);
     }
 
+    /// Relay-side session for an existing preamble (same members as `publish`).
+    pub fn attachRelaySession(self: *ChannelRs, message_id: []const u8, preamble: *const rs_strategy.RsPreamble) !void {
+        if (self.sessions.get(message_id) != null) return error.DuplicateMessage;
+
+        const mid = try self.allocator.dupe(u8, message_id);
+        errdefer self.allocator.free(mid);
+
+        var strat = try RsStrategy.newRelay(self.allocator, self.cfg, preamble);
+        errdefer strat.deinit();
+
+        const n = self.members.items.len;
+        const member_ids = try self.allocator.alloc([]u8, n);
+        errdefer {
+            for (member_ids) |m| self.allocator.free(m);
+            self.allocator.free(member_ids);
+        }
+        const stats = try self.allocator.alloc(broadcast_types.PeerSessionStats, n);
+        errdefer self.allocator.free(stats);
+
+        for (0..n) |i| {
+            member_ids[i] = try self.allocator.dupe(u8, self.members.items[i]);
+            stats[i] = .{ .peer_id = member_ids[i] };
+            try strat.attachPeer(member_ids[i], &stats[i]);
+        }
+
+        const sess = try self.allocator.create(SessionRs);
+        errdefer {
+            sess.deinit();
+            self.allocator.destroy(sess);
+        }
+        sess.* = .{
+            .allocator = self.allocator,
+            .message_id = mid,
+            .strategy = strat,
+            .member_ids = member_ids,
+            .stats = stats,
+        };
+
+        try self.sessions.put(self.allocator, mid, sess);
+    }
+
     pub fn sessionDrainOutbound(self: *ChannelRs, message_id: []const u8) !usize {
         const slot = self.sessions.getPtr(message_id) orelse return error.UnknownMessage;
         return slot.*.drainOutbound();
@@ -118,6 +161,26 @@ pub const ChannelRs = struct {
     pub fn sessionStrategy(self: *ChannelRs, message_id: []const u8) ?*RsStrategy {
         const slot = self.sessions.getPtr(message_id) orelse return null;
         return &slot.*.strategy;
+    }
+
+    /// Ingest a relay chunk: optional cross-session dedup, then `takeChunk`.
+    pub fn relayIngestChunk(
+        self: *ChannelRs,
+        registry: ?*dedup_registry_mod.DedupRegistry,
+        message_id: []const u8,
+        peer: []const u8,
+        chunk_id: rs_strategy.ChunkIdent,
+        data: []const u8,
+        dedup: ?*broadcast_types.DedupCancel,
+    ) (Allocator.Error || error{UnknownMessage})!broadcast_types.ChunkIngestResult {
+        const strat = self.sessionStrategy(message_id) orelse return error.UnknownMessage;
+        if (registry) |reg| {
+            const first = try reg.claim(self.allocator, self.id, message_id, chunk_id.index);
+            if (!first) {
+                return .{ .verdict = .redundant, .complete = false };
+            }
+        }
+        return strat.takeChunk(peer, chunk_id, data, dedup);
     }
 };
 
@@ -147,4 +210,64 @@ test "channel publish and drain to one member" {
     const decoded = try ch.sessionDecode("m1");
     defer gpa.free(decoded);
     try std.testing.expectEqualSlices(u8, &payload, decoded);
+}
+
+test "relay ingest registry blocks second claim same chunk index" {
+    const gpa = std.testing.allocator;
+    var eng = try Engine.init(gpa, "local", .{});
+    defer eng.deinit();
+
+    const cfg = RsConfig{
+        .data_shards = 4,
+        .parity_shards = 2,
+        .chunk_len = 0,
+        .bitmap_threshold = 0,
+        .forward_multiplier = 4,
+        .disable_bitmap = false,
+    };
+
+    const ch = try eng.attachChannelRs("topic", cfg);
+    try ch.addMember("peerA");
+    try ch.addMember("peerB");
+
+    const payload = [_]u8{ 9, 8, 7 };
+    var origin = try RsStrategy.newOrigin(gpa, cfg, &payload);
+    defer origin.deinit();
+
+    try ch.attachRelaySession("m1", &origin.preamble);
+
+    var reg: dedup_registry_mod.DedupRegistry = .{};
+    defer reg.deinit(gpa);
+
+    const chunk0 = origin.chunks[0];
+
+    var ga: dedup_mod.DedupGroup = .{};
+    var ta = ga.token();
+    const r1 = try ch.relayIngestChunk(&reg, "m1", "peerA", .{ .index = 0 }, chunk0, ta.dedupPtr());
+    try std.testing.expectEqual(broadcast_types.Verdict.accepted, r1.verdict);
+    try std.testing.expect(ga.fired);
+
+    const r2 = try ch.relayIngestChunk(&reg, "m1", "peerB", .{ .index = 0 }, chunk0, null);
+    try std.testing.expectEqual(broadcast_types.Verdict.redundant, r2.verdict);
+}
+
+test "relayIngestChunk unknown message" {
+    const gpa = std.testing.allocator;
+    var eng = try Engine.init(gpa, "local", .{ .enable_cross_session_dedup = true });
+    defer eng.deinit();
+
+    const cfg = RsConfig{
+        .data_shards = 4,
+        .parity_shards = 2,
+        .chunk_len = 0,
+        .bitmap_threshold = 0,
+        .forward_multiplier = 4,
+        .disable_bitmap = false,
+    };
+
+    const ch = try eng.attachChannelRs("topic", cfg);
+    try std.testing.expectError(
+        error.UnknownMessage,
+        ch.relayIngestChunk(eng.dedupRegistryPtr(), "missing", "peer", .{ .index = 0 }, &.{}, null),
+    );
 }

--- a/src/broadcast/engine.zig
+++ b/src/broadcast/engine.zig
@@ -2,12 +2,15 @@
 
 const std = @import("std");
 const ChannelRs = @import("channel_rs.zig").ChannelRs;
+const dedup_registry_mod = @import("../layer/dedup_registry.zig");
 const observer_mod = @import("observer.zig");
 
 const Allocator = std.mem.Allocator;
 
 pub const EngineConfig = struct {
     observer: observer_mod.Observer = .{},
+    /// When set, `Engine` owns a `DedupRegistry` for `relayIngestChunk`-style helpers.
+    enable_cross_session_dedup: bool = false,
 };
 
 pub const Engine = struct {
@@ -15,13 +18,19 @@ pub const Engine = struct {
     local_peer_id: []u8,
     config: EngineConfig,
     channels: std.StringHashMapUnmanaged(*ChannelRs),
+    dedup_registry: ?dedup_registry_mod.DedupRegistry = null,
 
     pub fn init(allocator: Allocator, local_peer_id: []const u8, config: EngineConfig) !Engine {
+        var dedup_registry: ?dedup_registry_mod.DedupRegistry = null;
+        if (config.enable_cross_session_dedup) {
+            dedup_registry = dedup_registry_mod.DedupRegistry{};
+        }
         return .{
             .allocator = allocator,
             .local_peer_id = try allocator.dupe(u8, local_peer_id),
             .config = config,
             .channels = .{},
+            .dedup_registry = dedup_registry,
         };
     }
 
@@ -33,7 +42,15 @@ pub const Engine = struct {
             self.allocator.destroy(ch);
         }
         self.channels.deinit(self.allocator);
+        if (self.dedup_registry) |*d| {
+            d.deinit(self.allocator);
+        }
         self.allocator.free(self.local_peer_id);
+    }
+
+    pub fn dedupRegistryPtr(self: *Engine) ?*dedup_registry_mod.DedupRegistry {
+        if (self.dedup_registry) |*d| return d;
+        return null;
     }
 
     pub fn attachChannelRs(

--- a/src/layer/broadcast_types.zig
+++ b/src/layer/broadcast_types.zig
@@ -13,6 +13,11 @@ pub const Verdict = enum(u8) {
     pending = 5,
 };
 
+pub const ChunkIngestResult = struct {
+    verdict: Verdict,
+    complete: bool,
+};
+
 /// Session passes this into `RsStrategy.takeChunk` so the strategy can cancel the dedup group.
 /// Nil-safe: `cancel(null)` is a no-op.
 pub const DedupCancel = struct {

--- a/src/layer/dedup_registry.zig
+++ b/src/layer/dedup_registry.zig
@@ -1,0 +1,93 @@
+//! Cross-session chunk dedup: first claim wins for `(channel_id, message_id, chunk_index)`.
+//! Complements per-strategy `takeChunk` redundancy (same index already stored).
+
+const std = @import("std");
+
+const Allocator = std.mem.Allocator;
+
+pub const DedupRegistry = struct {
+    seen: std.StringHashMapUnmanaged(void) = .{},
+
+    pub fn deinit(self: *DedupRegistry, allocator: Allocator) void {
+        var it = self.seen.keyIterator();
+        while (it.next()) |k| {
+            allocator.free(k.*);
+        }
+        self.seen.deinit(allocator);
+    }
+
+    /// `true` if this triple was not seen before (inserted). `false` if duplicate.
+    pub fn claim(
+        self: *DedupRegistry,
+        allocator: Allocator,
+        channel_id: []const u8,
+        message_id: []const u8,
+        chunk_index: i32,
+    ) Allocator.Error!bool {
+        const key = try makeKey(allocator, channel_id, message_id, chunk_index);
+        errdefer allocator.free(key);
+        if (self.seen.contains(key)) {
+            allocator.free(key);
+            return false;
+        }
+        try self.seen.put(allocator, key, {});
+        return true;
+    }
+
+    /// Drop every key for `message_id` on `channel_id` (e.g. after decode / session end).
+    pub fn forgetMessage(
+        self: *DedupRegistry,
+        allocator: Allocator,
+        channel_id: []const u8,
+        message_id: []const u8,
+    ) void {
+        const prefix = makePrefixLen(channel_id, message_id);
+        var to_remove: std.ArrayListUnmanaged([]const u8) = .{};
+        defer to_remove.deinit(allocator);
+
+        var it = self.seen.iterator();
+        while (it.next()) |ent| {
+            if (keyMatchesPrefix(ent.key_ptr.*, channel_id, message_id, prefix)) {
+                to_remove.append(allocator, ent.key_ptr.*) catch return;
+            }
+        }
+        for (to_remove.items) |k| {
+            if (self.seen.fetchRemove(k)) |kv| {
+                allocator.free(kv.key);
+            }
+        }
+    }
+};
+
+fn makeKey(allocator: Allocator, ch: []const u8, msg: []const u8, idx: i32) ![]u8 {
+    return std.fmt.allocPrint(allocator, "{s}\x00{s}\x00{d}", .{ ch, msg, idx });
+}
+
+fn makePrefixLen(ch: []const u8, msg: []const u8) usize {
+    return ch.len + 1 + msg.len + 1;
+}
+
+fn keyMatchesPrefix(key: []const u8, ch: []const u8, msg: []const u8, prefix_len: usize) bool {
+    if (key.len < prefix_len + 1) return false;
+    if (!std.mem.startsWith(u8, key, ch)) return false;
+    if (key[ch.len] != 0) return false;
+    const rest = key[ch.len + 1 ..];
+    if (!std.mem.startsWith(u8, rest, msg)) return false;
+    if (rest[msg.len] != 0) return false;
+    return true;
+}
+
+test "dedup registry claim and forget" {
+    const gpa = std.testing.allocator;
+    var reg: DedupRegistry = .{};
+    defer reg.deinit(gpa);
+
+    try std.testing.expect(try reg.claim(gpa, "ch", "m1", 0));
+    try std.testing.expect(!try reg.claim(gpa, "ch", "m1", 0));
+    try std.testing.expect(try reg.claim(gpa, "ch", "m1", 1));
+    try std.testing.expect(try reg.claim(gpa, "ch", "m2", 0));
+
+    reg.forgetMessage(gpa, "ch", "m1");
+    try std.testing.expect(try reg.claim(gpa, "ch", "m1", 0));
+    try std.testing.expect(!try reg.claim(gpa, "ch", "m2", 0));
+}

--- a/src/layer/rs_strategy.zig
+++ b/src/layer/rs_strategy.zig
@@ -304,7 +304,7 @@ pub const RsStrategy = struct {
         chunk_id: ChunkIdent,
         data: []const u8,
         dedup: ?*broadcast_types.DedupCancel,
-    ) Allocator.Error!struct { verdict: broadcast_types.Verdict, complete: bool } {
+    ) Allocator.Error!broadcast_types.ChunkIngestResult {
         const idx_i = chunk_id.index;
         if (idx_i < 0 or @as(usize, @intCast(idx_i)) >= self.total_chunks) {
             return .{ .verdict = .invalid, .complete = false };

--- a/src/layer/verify_workers.zig
+++ b/src/layer/verify_workers.zig
@@ -1,0 +1,108 @@
+//! Background SHA256 chunk checks feeding `VerifyQueue` (Go-style async verify workers).
+//!
+//! When `n_jobs > 0`, the pool uses `allocator` from worker threads — use a thread-safe
+//! allocator (for example `page_allocator` or a locked GPA), not `std.testing.allocator`.
+
+const std = @import("std");
+const broadcast_types = @import("broadcast_types.zig");
+const verify_queue_mod = @import("verify_queue.zig");
+
+const Allocator = std.mem.Allocator;
+
+pub const VerifyJob = struct {
+    handle: broadcast_types.ChunkHandle,
+    expected_hash: [32]u8,
+    data: []const u8,
+};
+
+pub const VerifyWorkerPool = struct {
+    allocator: Allocator,
+    pool: std.Thread.Pool,
+    out: *verify_queue_mod.VerifyQueue,
+    out_mutex: std.Thread.Mutex = .{},
+
+    pub fn init(allocator: Allocator, n_jobs: usize, out: *verify_queue_mod.VerifyQueue) !VerifyWorkerPool {
+        var pool: std.Thread.Pool = undefined;
+        try pool.init(.{ .allocator = allocator, .n_jobs = @as(?usize, n_jobs) });
+        return .{
+            .allocator = allocator,
+            .pool = pool,
+            .out = out,
+        };
+    }
+
+    pub fn deinit(self: *VerifyWorkerPool) void {
+        self.pool.deinit();
+    }
+
+    /// Queue work on the pool; `job.data` is copied.
+    pub fn schedule(self: *VerifyWorkerPool, job: VerifyJob) !void {
+        const owned = try self.allocator.dupe(u8, job.data);
+        errdefer self.allocator.free(owned);
+        try self.pool.spawn(runOne, .{ self, job.handle, job.expected_hash, owned });
+    }
+
+    /// Same as `schedule`, but increments `wg` before enqueue and finishes after the result is pushed.
+    pub fn scheduleWait(self: *VerifyWorkerPool, wg: *std.Thread.WaitGroup, job: VerifyJob) !void {
+        const owned = try self.allocator.dupe(u8, job.data);
+        errdefer self.allocator.free(owned);
+        self.pool.spawnWg(wg, runOne, .{ self, job.handle, job.expected_hash, owned });
+    }
+
+    /// Synchronous path (no pool thread): hash, push. `runOne` frees the dupe.
+    pub fn verifyInline(self: *VerifyWorkerPool, job: VerifyJob) Allocator.Error!void {
+        const owned = try self.allocator.dupe(u8, job.data);
+        runOne(self, job.handle, job.expected_hash, owned);
+    }
+};
+
+fn runOne(
+    parent: *VerifyWorkerPool,
+    handle: broadcast_types.ChunkHandle,
+    expected: [32]u8,
+    data: []u8,
+) void {
+    defer parent.allocator.free(data);
+    var digest: [32]u8 = undefined;
+    std.crypto.hash.sha2.Sha256.hash(data, &digest, .{});
+    const verdict: broadcast_types.Verdict = if (std.mem.eql(u8, &digest, &expected))
+        .accepted
+    else
+        .invalid;
+
+    parent.out_mutex.lock();
+    defer parent.out_mutex.unlock();
+    parent.out.push(parent.allocator, .{ .handle = handle, .verdict = verdict }) catch {
+        @panic("VerifyWorkerPool: out queue OOM");
+    };
+}
+
+test "verify worker pool inline pushes verdicts" {
+    const gpa = std.testing.allocator;
+
+    var q: verify_queue_mod.VerifyQueue = .{};
+    defer q.deinit(gpa);
+
+    // No pool threads: testing allocator is single-threaded only. `verifyInline` still runs `runOne`.
+    var pool = try VerifyWorkerPool.init(gpa, 0, &q);
+    defer pool.deinit();
+
+    var good: [32]u8 = undefined;
+    std.crypto.hash.sha2.Sha256.hash("ok", &good, .{});
+
+    try pool.verifyInline(.{ .handle = 7, .expected_hash = good, .data = "ok" });
+    try pool.verifyInline(.{ .handle = 8, .expected_hash = good, .data = "bad" });
+
+    const r0 = q.popFront().?;
+    const r1 = q.popFront().?;
+    try std.testing.expect(q.popFront() == null);
+
+    var saw7_accept = false;
+    var saw8_invalid = false;
+    for ([_]verify_queue_mod.VerifyRecord{ r0, r1 }) |r| {
+        if (r.handle == 7 and r.verdict == .accepted) saw7_accept = true;
+        if (r.handle == 8 and r.verdict == .invalid) saw8_invalid = true;
+    }
+    try std.testing.expect(saw7_accept);
+    try std.testing.expect(saw8_invalid);
+}

--- a/src/root.zig
+++ b/src/root.zig
@@ -22,7 +22,9 @@ pub const layer = struct {
     pub const rs_init = @import("layer/rs_init.zig");
     pub const rs_strategy = @import("layer/rs_strategy.zig");
     pub const dedup = @import("layer/dedup.zig");
+    pub const dedup_registry = @import("layer/dedup_registry.zig");
     pub const verify_queue = @import("layer/verify_queue.zig");
+    pub const verify_workers = @import("layer/verify_workers.zig");
 };
 
 /// Session / engine / RS channel stack aligned with ethp2p `broadcast/` (single-threaded `drive` style).
@@ -38,7 +40,9 @@ test {
     _ = wire;
     _ = layer;
     _ = layer.dedup;
+    _ = layer.dedup_registry;
     _ = layer.verify_queue;
+    _ = layer.verify_workers;
     _ = sim.rs_mesh;
     _ = sim.gossipsub_transport;
     _ = sim.gossipsub_protocol;


### PR DESCRIPTION
Suggested **first** in the roadmap stack: Go-style multi-peer dedup **registry** and background verify workers (extends `layer.dedup`, `layer.verify_queue`).

Placeholder commit only — implement here, then mark ready for review.