### PR TITLE
ci,docs,justfile: Zig toolchain alignment (issue #15)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,6 +21,20 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - name: minimum_zig_version matches CI ZIG_VERSION
+        run: |
+          set -euo pipefail
+          want="${ZIG_VERSION}"
+          got="$(sed -n 's/^[[:space:]]*\.minimum_zig_version = "\([^"]*\)".*/\1/p' build.zig.zon | head -1)"
+          if test -z "$got"; then
+            echo "error: could not parse minimum_zig_version from build.zig.zon" >&2
+            exit 1
+          fi
+          if test "$got" != "$want"; then
+            echo "error: build.zig.zon minimum_zig_version=${got} but CI ZIG_VERSION=${want}" >&2
+            exit 1
+          fi
+
       - uses: mlugg/setup-zig@v2
         with:
           version: ${{ env.ZIG_VERSION }}

--- a/UPSTREAM.md
+++ b/UPSTREAM.md
@@ -2,11 +2,17 @@
 
 This repository tracks **[ethp2p](https://github.com/ethp2p/ethp2p)**.
 
+## Zig toolchain
+
+`build.zig.zon` `minimum_zig_version` must match the `ZIG_VERSION` environment variable in [`.github/workflows/ci.yml`](.github/workflows/ci.yml). CI fails the job if they differ, so bump both when raising the supported Zig release.
+
 ## Pinned revision
 
 The vendored `.proto` files and golden test vectors were checked against reference commit:
 
 `125bdaa3985a8cbe9f24d53155828312777b73fc`
+
+As of the last maintenance pass, **ethp2p** `main` still points at this commit, so `proto/*.proto` matched `broadcast/pb/`, `protocol/pb/`, and `broadcast/rs/pb/` in that tree without edits.
 
 When updating:
 

--- a/justfile
+++ b/justfile
@@ -27,6 +27,17 @@ fmt:
 fmt-check:
     zig fmt --check .
 
+# Same assertion as CI: parse ZIG_VERSION from the workflow file and compare to build.zig.zon.
+check-zig-ci-align:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    want="$(sed -n 's/^[[:space:]]*ZIG_VERSION: \([^[:space:]]*\).*/\1/p' .github/workflows/ci.yml | head -1)"
+    test -n "$want" || { echo "could not parse ZIG_VERSION from .github/workflows/ci.yml"; exit 1; }
+    got="$(sed -n 's/^[[:space:]]*\.minimum_zig_version = "\([^"]*\)".*/\1/p' build.zig.zon | head -1)"
+    test -n "$got" || { echo "could not parse build.zig.zon"; exit 1; }
+    test "$got" = "$want" || { echo "build.zig.zon minimum_zig_version=$got, ci.yml ZIG_VERSION=$want"; exit 1; }
+    echo "OK: minimum_zig_version=$got"
+
 # Local Zig caches and install prefix only.
 clean:
     rm -rf .zig-cache zig-out


### PR DESCRIPTION
## Summary

Addresses [#15](https://github.com/ch4r10t33r/zig-ethp2p/issues/15): keep toolchain docs and automation aligned.

## Changes

- **CI**: After checkout, assert `build.zig.zon` `minimum_zig_version` equals `env.ZIG_VERSION` so they cannot drift silently.
- **UPSTREAM.md**: Zig toolchain section + note that ethp2p `main` still matches the existing pinned commit (no `proto/` edits this round).
- **justfile**: `check-zig-ci-align` runs the same comparison locally (parses `ZIG_VERSION` from the workflow file).

## Proto sync

Checked [ethp2p](https://github.com/ethp2p/ethp2p) `main` at `125bdaa3985a8cbe9f24d53155828312777b73fc` — same as `UPSTREAM.md`; vendored protos already match.

Closes #15.