### PR TITLE
transport: eth-ec-quic scaffold (ALPN, config, CI smoke test)

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ Zig helpers for the wire formats of **[ethp2p](https://github.com/ethp2p/ethp2p)
 | `PartialMessagesExtension` (nested in `RPC.partial`) | libp2p `rpc.proto` field 10 body | `encodePartialMessagesExtension`, `decodePartialMessagesExtensionOwned` |
 | Unsigned-varint length prefix before `RPC` body | common libp2p framing | `encodeRpcLengthPrefixed`, `decodeRpcLengthPrefixedPrefix` |
 | In-process duplex for length-prefixed `RPC` (simnet-style, no TCP/QUIC) | pair of `Endpoint`s over bounded byte queues | `sim.gossipsub_rpc_host` (`Link`, `Endpoint.sendRpc` / `recvRpcOwned`) |
+| QUIC transport (**scaffold** — ALPN `eth-ec-broadcast`, config shape, UDP bind smoke test; no TLS/QUIC stack linked) | [`sim/host.go`](https://github.com/ethp2p/ethp2p/blob/main/sim/host.go) `QUICHost`, `defaultQuicConfig` | `transport.eth_ec_quic` |
 | **Still open** | — | [Pending work](#pending-work) |
 
 ## Scope on `main` (at a glance)
@@ -51,6 +52,7 @@ This is **what is already implemented**—not the backlog. Per-module mapping an
 - **EC scheme id:** `layer.ec_scheme` (`EcSchemeKind`, `"reed-solomon"` wire name); only Reed–Solomon is wired end-to-end ([#14](https://github.com/ch4r10t33r/zig-ethp2p/issues/14) tracks RLNC and further schemes).
 - **Abstract RS mesh:** heap-backed graphs and `PeerSessionStats` (`sim.rs_mesh`): 2-node, 4-node ring, 6-node `TestNetwork`-style topology, **partition/heal** line test, chunk-len variant; with `ZIG_ETHP2P_STRESS=1`, larger six-node budget plus **8-** and **16-node** rings.
 - **Gossipsub (sim / wire helpers):** transport, protocol, broadcast, interop, `RPC` encode/decode (including **`partial`** / `PartialMessagesExtension`), full `ControlMessage`, varint length prefix, in-process **`gossipsub_rpc_host`** for tests (`sim.gossipsub_*`, `broadcast.gossip`).
+- **QUIC (experimental):** `transport.eth_ec_quic` — ALPN and tunables aligned with ethp2p’s illustrative QUIC host; `listen` / `dial` not implemented until a QUIC+TLS dependency is integrated.
 - **CI:** aligned with [ethp2p’s `ci.yml`](https://github.com/ethp2p/ethp2p/blob/main/.github/workflows/ci.yml): `zig build test-broadcast`, `test-sim-rs`, `test-sim-gossipsub` (Debug + TSan), `test-stress-ci` on **`main` only**, plus lint (`zig fmt --check`, `zig build`, `zig ast-check`). `build.zig.zon` **`minimum_zig_version`** must match workflow **`ZIG_VERSION`**; `just check-zig-ci-align` checks that locally.
 - **One-shot local verification:** `zig build test` runs the full suite.
 
@@ -58,7 +60,7 @@ This is **what is already implemented**—not the backlog. Per-module mapping an
 
 What is **not** covered yet (the [implementation table](#implementation-status-vs-reference) remains authoritative for details):
 
-- **Transport:** production libp2p/QUIC (ethp2p’s in-repo QUIC is illustrative; this repo stays strategy + wire + sim helpers).
+- **Transport:** full **QUIC + TLS 1.3** stack, stream wiring to `wire.*`, and production **libp2p** integration — beyond `transport.eth_ec_quic` scaffold (see module doc for candidate deps and CI notes).
 - **Gossipsub `RPC`:** protobuf extension fields beyond **`partial`** / `PartialMessagesExtension` (field 10).
 - **Erasure coding:** `layer.ec_scheme` holds the scheme enum and `"reed-solomon"` wire name; **RLNC** (strategy, preamble, chunk layout) and any further `Scheme` types remain ([#14](https://github.com/ch4r10t33r/zig-ethp2p/issues/14)).
 - **Engine:** optional channel-style event loop / `VerdictPending` for non-RS schemes.

--- a/UPSTREAM.md
+++ b/UPSTREAM.md
@@ -24,6 +24,10 @@ When updating:
 2. Run `zig build test` (golden bytes must still match `google.golang.org/protobuf` output from that tree).
 3. Bump the commit hash in this file.
 
+## QUIC / UDP transport
+
+`src/transport/eth_ec_quic.zig` mirrors **ALPN** `eth-ec-broadcast` and high-level **quic-go-style** limits from ethp2p `sim/host.go`. It does not link a QUIC implementation yet; integrating something like [`gitlab.com/devnw/zig/quic`](https://gitlab.com/devnw/zig/quic) implies extra system libs (e.g. OpenSSL on Linux/macOS in that tree), likely Zig **0.15.1+**, and CI image updates—prefer an opt-in `build.zig` step until stable.
+
 ## EC schemes (issue [#14](https://github.com/ch4r10t33r/zig-ethp2p/issues/14))
 
 `src/layer/ec_scheme.zig` defines `EcSchemeKind` and the `"reed-solomon"` string aligned with `broadcast/rs/types.go` `NewScheme`. Only Reed–Solomon is implemented end-to-end; RLNC needs spec’d preamble / chunk types and a strategy implementation before wire changes.

--- a/src/ci_root_broadcast.zig
+++ b/src/ci_root_broadcast.zig
@@ -2,6 +2,7 @@
 //! When adding `broadcast/` modules or layer test files, keep this aligned with `src/root.zig` (excluding `sim`).
 
 test {
+    _ = @import("transport/eth_ec_quic.zig");
     _ = @import("wire/root.zig");
     _ = @import("layer/bitmap.zig");
     _ = @import("layer/dedup.zig");

--- a/src/root.zig
+++ b/src/root.zig
@@ -1,6 +1,7 @@
 //! Zig implementation of [ethp2p](https://github.com/ethp2p/ethp2p) wire formats.
 //! Behavior is validated against the reference Go stack; see `UPSTREAM.md`.
 //! Split CI test roots live in `ci_root_broadcast.zig`, `ci_root_sim_rs.zig`, and `ci_root_sim_gossipsub.zig`; update them when adding tests under those areas.
+//! Experimental QUIC transport scaffolding: `transport.eth_ec_quic`.
 
 pub const wire = @import("wire/root.zig");
 
@@ -32,6 +33,11 @@ pub const layer = struct {
 };
 
 /// Session / engine / RS channel stack aligned with ethp2p `broadcast/` (single-threaded `drive` style).
+/// Production-style transport (QUIC) — see `transport/eth_ec_quic.zig`; not yet wired to `wire.*` sessions.
+pub const transport = struct {
+    pub const eth_ec_quic = @import("transport/eth_ec_quic.zig");
+};
+
 pub const broadcast = struct {
     pub const observer = @import("broadcast/observer.zig");
     pub const engine = @import("broadcast/engine.zig");
@@ -43,6 +49,7 @@ pub const broadcast = struct {
 
 test {
     _ = wire;
+    _ = transport.eth_ec_quic;
     _ = layer;
     _ = layer.dedup;
     _ = layer.dedup_registry;

--- a/src/transport/eth_ec_quic.zig
+++ b/src/transport/eth_ec_quic.zig
@@ -1,0 +1,74 @@
+//! QUIC transport shape for ethp2p-style EC broadcast (reference: `github.com/ethp2p/ethp2p` `sim/host.go`).
+//!
+//! ethp2p uses **quic-go** with ALPN **`eth-ec-broadcast`**, a long `MaxIdleTimeout`, and high stream
+//! limits for per-chunk uni-streams. This repository does not ship a QUIC stack in-tree yet; the
+//! types below anchor configuration and entry points for a future integration.
+//!
+//! **Next steps (production path):**
+//!
+//! - Link a TLS 1.3 + QUIC v1 implementation. One candidate is [`gitlab.com/devnw/zig/quic`](https://gitlab.com/devnw/zig/quic)
+//!   (Zig **0.15.1+**, OpenSSL `ssl`/`crypto` on non-Windows in its upstream `build.zig`).
+//! - Drive **BCAST / SESS / CHUNK** streams using `wire.*` framing on top of QUIC streams (or datagrams if spec allows).
+//! - CI: install OpenSSL dev headers where the QUIC dependency is built; keep default `zig build test` free of that link until the integration is opt-in (e.g. `build.zig` `-Denable-quic`).
+//!
+//! Until then, `listen` / `dial` return `error.TransportNotImplemented`.
+
+const std = @import("std");
+const builtin = @import("builtin");
+
+/// Application-Layer Protocol Negotiation identifier used by ethp2p’s QUIC host (`NextProtos`).
+pub const alpn_eth_ec_broadcast: []const u8 = "eth-ec-broadcast";
+
+/// Tunables mirroring the intent of ethp2p `sim/host.go` `defaultQuicConfig` (not wire-identical to quic-go).
+pub const EthEcQuicConfig = struct {
+    /// Effectively “disable idle close” — ethp2p uses a one-year cap because quic-go rejects `MaxInt64`.
+    max_idle_timeout_ns: u64 = 365 * std.time.ns_per_day,
+    max_incoming_streams: u32 = 16_384,
+    max_incoming_uni_streams: u32 = 16_384,
+
+    pub fn default() EthEcQuicConfig {
+        return .{};
+    }
+};
+
+pub const ListenAddress = struct {
+    host: []const u8,
+    port: u16,
+};
+
+/// Placeholder listener; will wrap a real QUIC `Listener` once a stack is linked.
+pub const EthEcQuicListener = struct {
+    _phantom: u8 = 0,
+};
+
+/// Returns when a QUIC stack is integrated and bound to `address`.
+pub fn listen(_: EthEcQuicConfig, _: ListenAddress) error{TransportNotImplemented}!EthEcQuicListener {
+    return error.TransportNotImplemented;
+}
+
+/// Returns when QUIC dial + TLS handshake to `remote` is implemented.
+pub fn dial(_: EthEcQuicConfig, _: ListenAddress) error{TransportNotImplemented}!void {
+    return error.TransportNotImplemented;
+}
+
+test "ALPN matches ethp2p QUIC host" {
+    try std.testing.expectEqualStrings("eth-ec-broadcast", alpn_eth_ec_broadcast);
+}
+
+test "default QUIC-ish config has ethp2p-scale stream headroom" {
+    const c = EthEcQuicConfig.default();
+    try std.testing.expectEqual(@as(u32, 16_384), c.max_incoming_streams);
+    try std.testing.expectEqual(@as(u32, 16_384), c.max_incoming_uni_streams);
+    try std.testing.expect(c.max_idle_timeout_ns >= std.time.ns_per_day);
+}
+
+test "UDP bind ephemeral (bootstrap for future QUIC socket)" {
+    if (builtin.os.tag == .windows) return error.SkipZigTest;
+    if (builtin.os.tag == .wasi) return error.SkipZigTest;
+
+    const sock = try std.posix.socket(std.posix.AF.INET, std.posix.SOCK.DGRAM, std.posix.IPPROTO.UDP);
+    defer std.posix.close(sock);
+
+    const any = try std.net.Address.parseIp("127.0.0.1", 0);
+    try std.posix.bind(sock, &any.any, any.getOsSockLen());
+}


### PR DESCRIPTION
## Summary
Adds `transport.eth_ec_quic`: ALPN `eth-ec-broadcast`, `EthEcQuicConfig` defaults aligned with ethp2p `sim/host.go`, and UDP bind smoke test. `listen` / `dial` remain `error.TransportNotImplemented` until a QUIC+TLS stack is linked.

## Docs
- README implementation table + scope + pending work clarification.
- `UPSTREAM.md` QUIC / transport notes.

## CI
- `src/ci_root_broadcast.zig` imports the module so `zig build test-broadcast` runs transport tests.

## Follow-up (tracked)
- #26 — QUIC + TLS 1.3 integration (`listen` / `dial`, opt-in build, CI deps)
- #27 — BCAST / SESS / CHUNK over QUIC using `wire.*`
- #28 — Production libp2p interop beyond raw QUIC

## Checklist
- [x] `zig fmt`
- [x] `zig build test`
- [x] `zig build test-broadcast`