### PR TITLE
QUIC transport: lsquic + BoringSSL shim (issue #26)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -96,14 +96,11 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Install OpenSSL development headers
-        run: sudo apt-get update && sudo apt-get install -y libssl-dev
-
       - uses: mlugg/setup-zig@v2
         with:
           version: ${{ env.ZIG_VERSION }}
 
-      - name: QUIC transport tests (devnw/quic + TLS)
+      - name: QUIC transport tests (in-repo lsquic + BoringSSL)
         run: zig build test-quic -Denable-quic --summary all
 
   large-network-rs:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -93,6 +93,8 @@ jobs:
 
   quic-transport:
     runs-on: ubuntu-latest
+    # Default job cap is 6h; without this, a hung `quic.poll` / test subprocess can burn the full budget.
+    timeout-minutes: 45
     steps:
       - uses: actions/checkout@v4
 
@@ -100,8 +102,9 @@ jobs:
         with:
           version: ${{ env.ZIG_VERSION }}
 
+      # `timeout` (coreutils) fails the step with 124 if the build or test binary never finishes.
       - name: QUIC transport tests (in-repo lsquic + BoringSSL)
-        run: zig build test-quic -Denable-quic --summary all
+        run: timeout 40m zig build test-quic -Denable-quic --summary all
 
   large-network-rs:
     runs-on: ubuntu-latest

--- a/build.zig
+++ b/build.zig
@@ -1,10 +1,61 @@
 const std = @import("std");
 
-fn linkOpenSslNonWindows(step: *std.Build.Step.Compile, resolved_target: std.Build.ResolvedTarget) void {
-    if (resolved_target.result.os.tag == .windows) return;
+const QuicLinkBundle = struct {
+    quic_mod: *std.Build.Module,
+    lsquic_lib: *std.Build.Step.Compile,
+    ssl_lib: *std.Build.Step.Compile,
+    crypto_lib: *std.Build.Step.Compile,
+};
+
+fn addLsquicQuicModule(
+    b: *std.Build,
+    lsquic_pkg: *std.Build.Dependency,
+    target: std.Build.ResolvedTarget,
+    optimize: std.builtin.OptimizeMode,
+) QuicLinkBundle {
+    const nested = lsquic_pkg.builder;
+    const boringssl_dep = nested.dependency("boringssl", .{
+        .target = target,
+        .optimize = optimize,
+    });
+    const lsquic_upstream = nested.dependency("lsquic", .{
+        .target = target,
+        .optimize = optimize,
+    });
+    const openssl_src = boringssl_dep.builder.dependency("ssl", .{});
+
+    const quic_mod = b.addModule("quic", .{
+        .root_source_file = b.path("src/transport/lsquic_quic_shim.zig"),
+        .target = target,
+        .optimize = optimize,
+        .link_libc = true,
+    });
+    quic_mod.addIncludePath(lsquic_upstream.path("include"));
+    quic_mod.addIncludePath(openssl_src.path("include"));
+
+    return .{
+        .quic_mod = quic_mod,
+        .lsquic_lib = lsquic_pkg.artifact("lsquic"),
+        .ssl_lib = boringssl_dep.artifact("ssl"),
+        .crypto_lib = boringssl_dep.artifact("crypto"),
+    };
+}
+
+fn linkQuicLibs(
+    step: *std.Build.Step.Compile,
+    bundle: QuicLinkBundle,
+    resolved_target: std.Build.ResolvedTarget,
+) void {
     step.linkLibC();
-    step.linkSystemLibrary("ssl");
-    step.linkSystemLibrary("crypto");
+    step.linkLibrary(bundle.lsquic_lib);
+    step.linkLibrary(bundle.ssl_lib);
+    step.linkLibrary(bundle.crypto_lib);
+    const zlib_name: []const u8 = if (resolved_target.result.os.tag == .windows) "zlib1" else "z";
+    step.linkSystemLibrary(zlib_name);
+    if (resolved_target.result.os.tag != .windows) {
+        step.linkSystemLibrary("pthread");
+        step.linkSystemLibrary("m");
+    }
 }
 
 fn wireZigEthP2pModule(
@@ -20,21 +71,23 @@ pub fn build(b: *std.Build) void {
     const target = b.standardTargetOptions(.{});
     const optimize = b.standardOptimizeOption(.{});
 
-    const enable_quic = b.option(bool, "enable-quic", "Link OpenSSL + devnw/quic (real listen/dial)") orelse false;
+    const enable_quic = b.option(bool, "enable-quic", "Build lsquic + BoringSSL in-repo QUIC shim (listen/dial)") orelse false;
 
     if (enable_quic and target.result.os.tag == .windows) {
-        std.debug.panic("-Denable-quic is unsupported on Windows in this repository (OpenSSL layout differs from non-Windows).", .{});
+        std.debug.panic("-Denable-quic is unsupported on Windows in this repository (lsquic_zig build is non-Windows focused).", .{});
     }
 
     const zig_opts = b.addOptions();
     zig_opts.addOption(bool, "enable_quic", enable_quic);
     const zig_opts_mod = zig_opts.createModule();
 
-    const quic_dep = if (enable_quic) b.dependency("quic", .{
-        .target = target,
-        .optimize = optimize,
-    }) else null;
-    const quic_mod = if (quic_dep) |qd| qd.module("quic") else null;
+    const quic_bundle: ?QuicLinkBundle = if (enable_quic) addLsquicQuicModule(
+        b,
+        b.dependency("lsquic_zig", .{ .target = target, .optimize = optimize }),
+        target,
+        optimize,
+    ) else null;
+    const quic_mod = if (quic_bundle) |qb| qb.quic_mod else null;
 
     const mod = b.addModule("zig_ethp2p", .{
         .root_source_file = b.path("src/root.zig"),
@@ -47,7 +100,7 @@ pub fn build(b: *std.Build) void {
         .name = "zig_ethp2p",
         .root_module = mod,
     });
-    if (enable_quic) linkOpenSslNonWindows(lib, target);
+    if (quic_bundle) |qb| linkQuicLibs(lib, qb, target);
 
     b.installArtifact(lib);
 
@@ -60,7 +113,7 @@ pub fn build(b: *std.Build) void {
     const lib_tests = b.addTest(.{
         .root_module = lib_tests_mod,
     });
-    if (enable_quic) linkOpenSslNonWindows(lib_tests, target);
+    if (quic_bundle) |qb| linkQuicLibs(lib_tests, qb, target);
     const run_lib_tests = b.addRunArtifact(lib_tests);
     const test_step = b.step("test", "Run library tests (full suite, same as local dev)");
     test_step.dependOn(&run_lib_tests.step);
@@ -79,11 +132,13 @@ pub fn build(b: *std.Build) void {
     const ci_opt: std.builtin.OptimizeMode = .Debug;
     const ci_tsan = true;
 
-    const quic_dep_ci = if (enable_quic) b.dependency("quic", .{
-        .target = ci_target,
-        .optimize = ci_opt,
-    }) else null;
-    const quic_mod_ci = if (quic_dep_ci) |qd| qd.module("quic") else null;
+    const quic_bundle_ci: ?QuicLinkBundle = if (enable_quic) addLsquicQuicModule(
+        b,
+        b.dependency("lsquic_zig", .{ .target = ci_target, .optimize = ci_opt }),
+        ci_target,
+        ci_opt,
+    ) else null;
+    const quic_mod_ci = if (quic_bundle_ci) |qb| qb.quic_mod else null;
 
     const broadcast_tests_mod = b.createModule(.{
         .root_source_file = b.path("src/ci_root_broadcast.zig"),
@@ -95,7 +150,7 @@ pub fn build(b: *std.Build) void {
     const broadcast_tests = b.addTest(.{
         .root_module = broadcast_tests_mod,
     });
-    if (enable_quic) linkOpenSslNonWindows(broadcast_tests, ci_target);
+    if (quic_bundle_ci) |qb| linkQuicLibs(broadcast_tests, qb, ci_target);
     const run_broadcast_tests = b.addRunArtifact(broadcast_tests);
     run_broadcast_tests.has_side_effects = true;
     const test_broadcast_step = b.step("test-broadcast", "Wire + layer + broadcast tests (ethp2p broadcast/ parity; TSan ≈ go -race)");
@@ -111,7 +166,7 @@ pub fn build(b: *std.Build) void {
     const sim_rs_tests = b.addTest(.{
         .root_module = sim_rs_tests_mod,
     });
-    if (enable_quic) linkOpenSslNonWindows(sim_rs_tests, ci_target);
+    if (quic_bundle_ci) |qb| linkQuicLibs(sim_rs_tests, qb, ci_target);
     const run_sim_rs = b.addRunArtifact(sim_rs_tests);
     run_sim_rs.has_side_effects = true;
     const test_sim_rs_step = b.step("test-sim-rs", "RS abstract mesh tests (ethp2p sim RS simnet job parity; TSan)");
@@ -127,10 +182,10 @@ pub fn build(b: *std.Build) void {
     const sim_gs_tests = b.addTest(.{
         .root_module = sim_gs_tests_mod,
     });
-    if (enable_quic) linkOpenSslNonWindows(sim_gs_tests, ci_target);
+    if (quic_bundle_ci) |qb| linkQuicLibs(sim_gs_tests, qb, ci_target);
     const run_sim_gs = b.addRunArtifact(sim_gs_tests);
     run_sim_gs.has_side_effects = true;
-    const test_sim_gs_step = b.step("test-sim-gossipsub", "Gossipsub sim tests (ethp2p sim Gossipsub job parity; TSan)");
+    const test_sim_gs_step = b.step("test-sim-gossipsub", "Gossipsub sim tests (ethp2p sim Gossipsub simnet job parity; TSan)");
     test_sim_gs_step.dependOn(&run_sim_gs.step);
 
     const stress_ci_mod = b.createModule(.{
@@ -143,7 +198,7 @@ pub fn build(b: *std.Build) void {
     const run_stress_ci = b.addTest(.{
         .root_module = stress_ci_mod,
     });
-    if (enable_quic) linkOpenSslNonWindows(run_stress_ci, ci_target);
+    if (quic_bundle_ci) |qb| linkQuicLibs(run_stress_ci, qb, ci_target);
     const run_stress_ci_run = b.addRunArtifact(run_stress_ci);
     run_stress_ci_run.setEnvironmentVariable("ZIG_ETHP2P_STRESS", "1");
     run_stress_ci_run.has_side_effects = true;
@@ -159,8 +214,8 @@ pub fn build(b: *std.Build) void {
     const quic_ci_tests = b.addTest(.{
         .root_module = quic_ci_mod,
     });
-    if (enable_quic) linkOpenSslNonWindows(quic_ci_tests, ci_target);
+    if (quic_bundle_ci) |qb| linkQuicLibs(quic_ci_tests, qb, ci_target);
     const run_quic_ci = b.addRunArtifact(quic_ci_tests);
-    const test_quic_step = b.step("test-quic", "Transport QUIC tests (use with -Denable-quic; OpenSSL on Linux/macOS)");
+    const test_quic_step = b.step("test-quic", "Transport QUIC tests (use with -Denable-quic; lsquic + BoringSSL)");
     test_quic_step.dependOn(&run_quic_ci.step);
 }

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -8,15 +8,15 @@
         "build.zig.zon",
         "src",
         "proto",
+        "vendor",
         "UPSTREAM.md",
         "README.md",
         "LICENSE",
         "justfile",
     },
     .dependencies = .{
-        .quic = .{
-            .url = "git+https://gitlab.com/devnw/zig/quic.git#bcf4a959186b4381910bed910b9ef01062882bbf",
-            .hash = "quic-0.1.10-gBIqUZ7gNQBZARuNrYktkGzRrU_V_WlU-ga_TygF1RMs",
+        .lsquic_zig = .{
+            .path = "vendor/lsquic_zig",
         },
     },
 }

--- a/src/transport/eth_ec_quic.zig
+++ b/src/transport/eth_ec_quic.zig
@@ -1,9 +1,9 @@
 //! QUIC transport for ethp2p-style EC broadcast (reference: `github.com/ethp2p/ethp2p` `sim/host.go`).
 //!
-//! With **`-Denable-quic`**, this links [`gitlab.com/devnw/zig/quic`](https://gitlab.com/devnw/zig/quic) (TLS 1.3 + QUIC v1) and OpenSSL
-//! on non-Windows. Default builds omit that dependency; `listen` / `dial` then return `error.TransportNotImplemented`.
+//! With **`-Denable-quic`**, this links the in-repo **lsquic** stack under `vendor/lsquic_zig` (LiteSpeed lsquic + BoringSSL).
+//! Default builds omit that dependency; `listen` / `dial` then return `error.TransportNotImplemented`.
 //!
-//! Run `zig build test-quic -Denable-quic` (after `libssl-dev` / equivalent) for the handshake smoke test.
+//! Run `zig build test-quic -Denable-quic` for the handshake smoke test (first build compiles BoringSSL + lsquic).
 
 const std = @import("std");
 const builtin = @import("builtin");

--- a/src/transport/eth_ec_quic_enabled.zig
+++ b/src/transport/eth_ec_quic_enabled.zig
@@ -127,7 +127,7 @@ test "QUIC listen + dial, TLS handshake, ALPN eth-ec-broadcast" {
     const remote_s = try std.fmt.allocPrint(alloc, "127.0.0.1:{d}", .{sport});
     defer alloc.free(remote_s);
 
-    const conn = try quic.connect(client_ep, remote_s, "localhost");
+    const conn = try quic.connect(client_ep, remote_s, test_certs.tls_server_name);
     errdefer quic.destroy(client_ep, conn);
 
     var server_conn: ?*quic.QuicConnection = null;
@@ -135,6 +135,9 @@ test "QUIC listen + dial, TLS handshake, ALPN eth-ec-broadcast" {
     while (rounds < 30_000) : (rounds += 1) {
         try quic.poll(srv, 0);
         try quic.poll(client_ep, 0);
+        // `poll(..., 1)` still returns immediately while UDP is readable; an explicit sleep
+        // advances wall clock so lsquic PTO/RTX and idle alarms can fire.
+        std.Thread.sleep(1 * std.time.ns_per_ms);
         if (server_conn == null) {
             server_conn = quic.tryAccept(srv);
         }

--- a/src/transport/eth_ec_quic_enabled.zig
+++ b/src/transport/eth_ec_quic_enabled.zig
@@ -135,9 +135,6 @@ test "QUIC listen + dial, TLS handshake, ALPN eth-ec-broadcast" {
     while (rounds < 30_000) : (rounds += 1) {
         try quic.poll(srv, 0);
         try quic.poll(client_ep, 0);
-        // `poll(..., 1)` still returns immediately while UDP is readable; an explicit sleep
-        // advances wall clock so lsquic PTO/RTX and idle alarms can fire.
-        std.Thread.sleep(1 * std.time.ns_per_ms);
         if (server_conn == null) {
             server_conn = quic.tryAccept(srv);
         }

--- a/src/transport/eth_ec_quic_enabled.zig
+++ b/src/transport/eth_ec_quic_enabled.zig
@@ -1,4 +1,4 @@
-//! QUIC + TLS implementation when `-Denable-quic` is set (`gitlab.com/devnw/zig/quic`).
+//! QUIC + TLS when `-Denable-quic` is set (`src/transport/lsquic_quic_shim.zig` + `vendor/lsquic_zig`).
 
 const std = @import("std");
 const quic = @import("quic");
@@ -64,7 +64,7 @@ pub fn dialImpl(
     const remote_s = try formatSocketAddr(allocator.*, remote);
     defer allocator.*.free(remote_s);
 
-    const conn = try quic.connect(client_ep, remote_s, "localhost");
+    const conn = try quic.connect(client_ep, remote_s, remote.host);
     errdefer quic.destroy(client_ep, conn);
 
     var rounds: u32 = 0;

--- a/src/transport/eth_ec_quic_test_certs.zig
+++ b/src/transport/eth_ec_quic_test_certs.zig
@@ -5,6 +5,8 @@
 // Generated from tls/tests/test_certs/ed25519_{cert,key}.der.
 //
 // Cert: self-signed, CN=ed25519.example.com, valid 2025-2035, 397 bytes.
+/// TLS client SNI / hostname passed to QUIC connect for this embedded test identity.
+pub const tls_server_name: []const u8 = "ed25519.example.com";
 // Key:  PKCS#8 wrapped Ed25519 seed, 48 bytes.
 
 /// Self-signed Ed25519 server certificate (DER).

--- a/src/transport/lsquic_quic_shim.zig
+++ b/src/transport/lsquic_quic_shim.zig
@@ -1,0 +1,543 @@
+//! QUIC API compatible with the former `gitlab.com/devnw/zig/quic` usage in this repo.
+//! Implemented with LiteSpeed lsquic + BoringSSL (see `vendor/lsquic_zig`).
+
+const std = @import("std");
+const posix = std.posix;
+
+const lsquic = @cImport({
+    @cInclude("lsquic.h");
+    @cInclude("lsquic_types.h");
+});
+
+const ossl = @cImport({
+    @cInclude("openssl/ssl.h");
+    @cInclude("openssl/evp.h");
+    @cInclude("openssl/x509.h");
+});
+
+var g_lsquic_global: bool = false;
+var g_alpn_selected_buf: [128]u8 = undefined;
+
+fn ensureLsquicGlobal() void {
+    if (g_lsquic_global) return;
+    _ = lsquic.lsquic_global_init(lsquic.LSQUIC_GLOBAL_CLIENT | lsquic.LSQUIC_GLOBAL_SERVER);
+    g_lsquic_global = true;
+}
+
+pub const QuicConfig = struct {
+    alpn: *const [1][]const u8,
+    inline_server_cert_der: ?[]const u8 = null,
+    inline_server_priv_p256: ?[]const u8 = null,
+    allow_insecure: bool = false,
+    max_idle_timeout_ms: u32 = 30_000,
+    max_udp_payload: u32 = 1350,
+};
+
+pub const QuicEndpoint = struct {
+    sock: posix.socket_t,
+    engine: *lsquic.lsquic_engine_t,
+    ssl_ctx: *ossl.SSL_CTX,
+    allocator: *std.mem.Allocator,
+    is_server: bool,
+    local_addr: std.net.Address,
+    resolved_local: ?std.net.Address,
+    accept_queue: std.ArrayListUnmanaged(*QuicConnection),
+    connect_slot: ?*QuicConnection,
+    first_alpn: []const u8,
+    alpn_wire: []u8,
+    alpn_cstr: [:0]u8,
+    base_plpmtu: u16,
+    sni_z: ?[:0]u8 = null,
+    settings: lsquic.lsquic_engine_settings,
+    api: lsquic.lsquic_engine_api,
+
+    fn isWildcardLocal(addr: std.net.Address) bool {
+        return switch (addr.any.family) {
+            posix.AF.INET => {
+                const b: *const [4]u8 = @ptrCast(&addr.in.sa.addr);
+                return std.mem.allEqual(u8, b, 0);
+            },
+            posix.AF.INET6 => {
+                const b: *const [16]u8 = @ptrCast(&addr.in6.sa.addr);
+                return std.mem.allEqual(u8, b, 0);
+            },
+            else => false,
+        };
+    }
+
+    fn resolveLocalForWildcard(local: std.net.Address, remote: std.net.Address) std.net.Address {
+        if (!isWildcardLocal(local)) return local;
+        const sock = posix.socket(remote.any.family, posix.SOCK.DGRAM, posix.IPPROTO.UDP) catch return local;
+        defer posix.close(sock);
+        posix.connect(sock, &remote.any, remote.getOsSockLen()) catch return local;
+        var resolved: std.net.Address = undefined;
+        var len: posix.socklen_t = @sizeOf(std.net.Address);
+        posix.getsockname(sock, &resolved.any, &len) catch return local;
+        resolved.setPort(local.getPort());
+        return resolved;
+    }
+
+    fn processEngine(self: *QuicEndpoint) void {
+        // Drive lsquic state. Long unbounded sleeps on `earliest_adv_tick` can exceed
+        // `es_idle_timeout` (~1s when max idle ms is 0) and close the connection mid-call.
+        // Allow only a small wall-clock budget per invocation so PTO-style timers can advance.
+        var slept_ns: u64 = 0;
+        const max_sleep_ns: u64 = 4 * std.time.ns_per_ms;
+        var guard: u32 = 0;
+        var zero_tick_streak: u32 = 0;
+        while (guard < 4096) : (guard += 1) {
+            lsquic.lsquic_engine_process_conns(self.engine);
+            while (lsquic.lsquic_engine_has_unsent_packets(self.engine) != 0) {
+                lsquic.lsquic_engine_send_unsent_packets(self.engine);
+            }
+            var diff_us: c_int = 0;
+            if (lsquic.lsquic_engine_earliest_adv_tick(self.engine, &diff_us) == 0) {
+                zero_tick_streak += 1;
+                if (zero_tick_streak >= 64) break;
+                continue;
+            }
+            zero_tick_streak = 0;
+            if (diff_us > 0 and slept_ns < max_sleep_ns) {
+                const us_ask: u64 = @intCast(@max(diff_us, 1));
+                const us_cap: u64 = @min(us_ask, 500);
+                const ns_try = us_cap * std.time.ns_per_us;
+                const ns = @min(ns_try, max_sleep_ns - slept_ns);
+                std.Thread.sleep(ns);
+                slept_ns += ns;
+            }
+        }
+    }
+
+    /// Reads one datagram if available. Returns `false` when the socket has no more buffered data.
+    fn recvOneIfAvailable(self: *QuicEndpoint) !bool {
+        var buf: [65536]u8 = undefined;
+        var peer: std.net.Address = undefined;
+        var peer_len: posix.socklen_t = @sizeOf(std.net.Address);
+        const n = posix.recvfrom(self.sock, &buf, 0, &peer.any, &peer_len) catch |err| switch (err) {
+            error.WouldBlock => return false,
+            else => |e| return e,
+        };
+        if (n == 0) return false;
+
+        if (!self.is_server) {
+            var la_len: posix.socklen_t = @sizeOf(std.net.Address);
+            posix.getsockname(self.sock, &self.local_addr.any, &la_len) catch {};
+        }
+
+        const local_sa: ?*const lsquic.struct_sockaddr = blk: {
+            if (self.is_server and isWildcardLocal(self.local_addr)) {
+                if (self.resolved_local == null) {
+                    self.resolved_local = resolveLocalForWildcard(self.local_addr, peer);
+                }
+                if (self.resolved_local) |*r| break :blk @ptrCast(@alignCast(&r.any));
+            }
+            break :blk @ptrCast(@alignCast(&self.local_addr.any));
+        };
+
+        _ = lsquic.lsquic_engine_packet_in(
+            self.engine,
+            buf[0..@intCast(n)].ptr,
+            @intCast(n),
+            local_sa,
+            @ptrCast(@alignCast(&peer.any)),
+            self,
+            0,
+        );
+        self.processEngine();
+        return true;
+    }
+
+    fn waitReadable(self: *QuicEndpoint, timeout_ms: u32) !bool {
+        if (timeout_ms == 0) return true;
+        var pfd = [_]posix.pollfd{.{
+            .fd = self.sock,
+            .events = posix.POLL.IN,
+            .revents = 0,
+        }};
+        const n = try posix.poll(&pfd, @intCast(timeout_ms));
+        return n > 0 and (pfd[0].revents & posix.POLL.IN) != 0;
+    }
+};
+
+pub const QuicConnection = struct {
+    raw: *lsquic.lsquic_conn_t,
+    ep: *QuicEndpoint,
+    hsk_ok: bool,
+};
+
+fn buildAlpnProtos(proto: []const u8, out: []u8) !usize {
+    if (proto.len > 255 or out.len < 1 + proto.len) return error.AlpnTooLong;
+    out[0] = @intCast(proto.len);
+    @memcpy(out[1 .. 1 + proto.len], proto);
+    return 1 + proto.len;
+}
+
+fn alpnSelectCb(
+    ssl: ?*ossl.SSL,
+    out_arg: [*c][*c]const u8,
+    out_len_arg: [*c]u8,
+    inp: [*c]const u8,
+    in_len: c_uint,
+    arg: ?*anyopaque,
+) callconv(.c) c_int {
+    _ = ssl;
+    _ = arg;
+    const out: *[*c]const u8 = @ptrCast(@alignCast(out_arg));
+    const out_len: *u8 = @ptrCast(out_len_arg);
+    const want = "eth-ec-broadcast";
+    var i: usize = 0;
+    const inlen_us: usize = @intCast(in_len);
+    while (i < inlen_us) {
+        const len: usize = @intCast(inp[i]);
+        i += 1;
+        if (i + len > inlen_us) return ossl.SSL_TLSEXT_ERR_ALERT_FATAL;
+        const offered: []const u8 = inp[i .. i + len];
+        i += len;
+        if (std.mem.eql(u8, offered, want)) {
+            if (len > g_alpn_selected_buf.len) return ossl.SSL_TLSEXT_ERR_ALERT_FATAL;
+            @memcpy(g_alpn_selected_buf[0..len], offered);
+            out.* = @ptrCast(g_alpn_selected_buf[0..len].ptr);
+            out_len.* = @intCast(len);
+            return ossl.SSL_TLSEXT_ERR_OK;
+        }
+    }
+    return ossl.SSL_TLSEXT_ERR_ALERT_FATAL;
+}
+
+fn makeSslCtxServer(cert_der: []const u8, key_der: []const u8) !*ossl.SSL_CTX {
+    const ctx = ossl.SSL_CTX_new(ossl.TLS_method()) orelse return error.TlsInit;
+    errdefer ossl.SSL_CTX_free(ctx);
+
+    if (ossl.SSL_CTX_set_min_proto_version(ctx, ossl.TLS1_3_VERSION) == 0) return error.TlsInit;
+    if (ossl.SSL_CTX_set_max_proto_version(ctx, ossl.TLS1_3_VERSION) == 0) return error.TlsInit;
+    _ = ossl.SSL_CTX_set_default_verify_paths(ctx);
+
+    var cert_p: [*c]const u8 = @ptrCast(cert_der.ptr);
+    const x509 = ossl.d2i_X509(null, &cert_p, @intCast(cert_der.len)) orelse return error.TlsInit;
+    defer ossl.X509_free(x509);
+    if (ossl.SSL_CTX_use_certificate(ctx, x509) == 0) return error.TlsInit;
+
+    var key_p: [*c]const u8 = @ptrCast(key_der.ptr);
+    const pkey = ossl.d2i_AutoPrivateKey(null, &key_p, @intCast(key_der.len)) orelse return error.TlsInit;
+    defer ossl.EVP_PKEY_free(pkey);
+    if (ossl.SSL_CTX_use_PrivateKey(ctx, pkey) == 0) return error.TlsInit;
+    if (ossl.SSL_CTX_check_private_key(ctx) == 0) return error.TlsInit;
+
+    // QUIC server ALPN is chosen in `ssl_negotiate_alpn` via this callback only; do not use
+    // `SSL_CTX_set_alpn_protos` here — in BoringSSL that field is the *client* ALPN wire list.
+    _ = ossl.SSL_CTX_set_alpn_select_cb(ctx, alpnSelectCb, null);
+    _ = ossl.SSL_CTX_set_verify(ctx, ossl.SSL_VERIFY_NONE, null);
+
+    return ctx;
+}
+
+fn makeSslCtxClient(allow_insecure: bool, alpn_wire: []const u8) !*ossl.SSL_CTX {
+    const ctx = ossl.SSL_CTX_new(ossl.TLS_method()) orelse return error.TlsInit;
+    errdefer ossl.SSL_CTX_free(ctx);
+
+    if (ossl.SSL_CTX_set_min_proto_version(ctx, ossl.TLS1_3_VERSION) == 0) return error.TlsInit;
+    if (ossl.SSL_CTX_set_max_proto_version(ctx, ossl.TLS1_3_VERSION) == 0) return error.TlsInit;
+    _ = ossl.SSL_CTX_set_default_verify_paths(ctx);
+
+    if (ossl.SSL_CTX_set_alpn_protos(ctx, alpn_wire.ptr, @intCast(alpn_wire.len)) != 0) return error.TlsInit;
+
+    if (allow_insecure) {
+        _ = ossl.SSL_CTX_set_verify(ctx, ossl.SSL_VERIFY_NONE, null);
+    } else {
+        _ = ossl.SSL_CTX_set_verify(ctx, ossl.SSL_VERIFY_PEER, null);
+    }
+
+    return ctx;
+}
+
+fn getSslCtx(peer_ctx: ?*anyopaque, _: ?*const lsquic.struct_sockaddr) callconv(.c) ?*lsquic.struct_ssl_ctx_st {
+    const ep: *QuicEndpoint = @ptrCast(@alignCast(peer_ctx.?));
+    return @ptrCast(ep.ssl_ctx);
+}
+
+fn packetsOut(ctx: ?*anyopaque, specs: ?[*]const lsquic.lsquic_out_spec, n_specs: u32) callconv(.c) c_int {
+    const ep: *QuicEndpoint = @ptrCast(@alignCast(ctx.?));
+    var sent: u32 = 0;
+    for (specs.?[0..n_specs]) |spec| {
+        var msg: posix.msghdr_const = std.mem.zeroes(posix.msghdr_const);
+        const dest_sa: ?*const posix.sockaddr = @ptrCast(@alignCast(spec.dest_sa));
+        if (dest_sa == null) return if (sent == 0) -1 else @intCast(sent);
+        msg.name = dest_sa;
+        msg.namelen = switch (dest_sa.?.family) {
+            posix.AF.INET => @sizeOf(posix.sockaddr.in),
+            posix.AF.INET6 => @sizeOf(posix.sockaddr.in6),
+            else => return if (sent == 0) -1 else @intCast(sent),
+        };
+        msg.iov = @ptrCast(spec.iov.?);
+        msg.iovlen = @intCast(spec.iovlen);
+
+        // lsquic inspects `errno` after this callback; Zig's `posix.sendmsg` error path can leave it stale.
+        const rc = posix.system.sendmsg(ep.sock, &msg, 0);
+        if (rc < 0) {
+            if (sent > 0) return @intCast(sent);
+            return -1;
+        }
+        sent += 1;
+    }
+    return @intCast(sent);
+}
+
+fn onNewConn(stream_if_ctx: ?*anyopaque, c: ?*lsquic.lsquic_conn_t) callconv(.c) ?*lsquic.lsquic_conn_ctx_t {
+    const ep: *QuicEndpoint = @ptrCast(@alignCast(stream_if_ctx.?));
+    const qc = ep.allocator.create(QuicConnection) catch return null;
+    qc.* = .{
+        .raw = c.?,
+        .ep = ep,
+        .hsk_ok = false,
+    };
+    lsquic.lsquic_conn_set_ctx(c, @ptrCast(qc));
+    if (ep.is_server) {
+        ep.accept_queue.append(ep.allocator.*, qc) catch {
+            ep.allocator.destroy(qc);
+            return null;
+        };
+    } else {
+        ep.connect_slot = qc;
+    }
+    return @ptrCast(qc);
+}
+
+fn onConnClosed(c: ?*lsquic.lsquic_conn_t) callconv(.c) void {
+    const qc: ?*QuicConnection = @ptrCast(@alignCast(lsquic.lsquic_conn_get_ctx(c.?)));
+    if (qc) |q| {
+        lsquic.lsquic_conn_set_ctx(c.?, null);
+        if (q.ep.connect_slot == q) q.ep.connect_slot = null;
+        q.ep.allocator.destroy(q);
+    }
+}
+
+fn onNewStream(stream_if_ctx: ?*anyopaque, s: ?*lsquic.lsquic_stream_t) callconv(.c) ?*lsquic.lsquic_stream_ctx_t {
+    _ = stream_if_ctx;
+    _ = s;
+    return null;
+}
+
+fn onStreamRead(s: ?*lsquic.lsquic_stream_t, h: ?*lsquic.lsquic_stream_ctx_t) callconv(.c) void {
+    _ = s;
+    _ = h;
+}
+
+fn onStreamWrite(s: ?*lsquic.lsquic_stream_t, h: ?*lsquic.lsquic_stream_ctx_t) callconv(.c) void {
+    _ = s;
+    _ = h;
+}
+
+fn onStreamClose(s: ?*lsquic.lsquic_stream_t, h: ?*lsquic.lsquic_stream_ctx_t) callconv(.c) void {
+    _ = s;
+    _ = h;
+}
+
+fn onHskDone(c: ?*lsquic.lsquic_conn_t, status: lsquic.enum_lsquic_hsk_status) callconv(.c) void {
+    if (status != lsquic.LSQ_HSK_OK and status != lsquic.LSQ_HSK_RESUMED_OK) return;
+    const qc: *QuicConnection = @ptrCast(@alignCast(lsquic.lsquic_conn_get_ctx(c.?)));
+    qc.hsk_ok = true;
+}
+
+const stream_if: lsquic.lsquic_stream_if = .{
+    .on_new_conn = onNewConn,
+    .on_goaway_received = null,
+    .on_conn_closed = onConnClosed,
+    .on_new_stream = onNewStream,
+    .on_read = onStreamRead,
+    .on_write = onStreamWrite,
+    .on_close = onStreamClose,
+    .on_dg_write = null,
+    .on_datagram = null,
+    .on_hsk_done = onHskDone,
+    .on_new_token = null,
+    .on_sess_resume_info = null,
+    .on_reset = null,
+    .on_conncloseframe_received = null,
+};
+
+fn parseBindAddr(s: []const u8) !std.net.Address {
+    const colon = std.mem.lastIndexOfScalar(u8, s, ':') orelse return error.BadAddress;
+    const host = s[0..colon];
+    const port = try std.fmt.parseInt(u16, s[colon + 1 ..], 10);
+    if (host.len >= 2 and host[0] == '[' and host[host.len - 1] == ']') {
+        return try std.net.Address.parseIp(host[1 .. host.len - 1], port);
+    }
+    return try std.net.Address.parseIp(host, port);
+}
+
+pub fn endpointInit(allocator: *std.mem.Allocator, bind_s: []const u8, qc: *QuicConfig) !*QuicEndpoint {
+    ensureLsquicGlobal();
+
+    const addr = try parseBindAddr(bind_s);
+    const is_server = qc.inline_server_cert_der != null;
+
+    const sock = try posix.socket(addr.any.family, posix.SOCK.DGRAM | posix.SOCK.NONBLOCK, posix.IPPROTO.UDP);
+    errdefer posix.close(sock);
+    const reuse: c_int = 1;
+    try posix.setsockopt(sock, posix.SOL.SOCKET, posix.SO.REUSEADDR, std.mem.asBytes(&reuse));
+    try posix.bind(sock, &addr.any, addr.getOsSockLen());
+
+    var local_addr: std.net.Address = undefined;
+    var la_len: posix.socklen_t = @sizeOf(std.net.Address);
+    try posix.getsockname(sock, &local_addr.any, &la_len);
+
+    const first_alpn = qc.alpn.*[0];
+    const alpn_wire = try allocator.alloc(u8, 1 + first_alpn.len);
+    errdefer allocator.free(alpn_wire);
+    const wlen = try buildAlpnProtos(first_alpn, alpn_wire);
+    if (wlen != alpn_wire.len) return error.AlpnTooLong;
+
+    const alpn_cstr = try allocator.allocSentinel(u8, first_alpn.len, 0);
+    errdefer allocator.free(alpn_cstr);
+    @memcpy(alpn_cstr[0..first_alpn.len], first_alpn);
+
+    const ssl_ctx: *ossl.SSL_CTX = if (is_server) blk: {
+        const cert = qc.inline_server_cert_der orelse return error.TlsInit;
+        const key = qc.inline_server_priv_p256 orelse return error.TlsInit;
+        break :blk try makeSslCtxServer(cert, key);
+    } else try makeSslCtxClient(qc.allow_insecure, alpn_wire);
+    errdefer ossl.SSL_CTX_free(ssl_ctx);
+
+    var flags_eng: c_uint = 0;
+    if (is_server) flags_eng |= lsquic.LSENG_SERVER;
+
+    var settings: lsquic.lsquic_engine_settings = undefined;
+    lsquic.lsquic_engine_init_settings(&settings, flags_eng);
+    settings.es_versions = lsquic.LSQUIC_IETF_VERSIONS;
+    if (is_server) {
+        // Default server `es_support_srej` issues Retry on tokenless Initials; that path
+        // can strand the handshake for loopback tests that expect a single mini→full flow.
+        settings.es_support_srej = 0;
+    }
+    const idle_s: u32 = @intCast(@max(1, qc.max_idle_timeout_ms / std.time.ms_per_s));
+    settings.es_idle_timeout = @min(idle_s, 600);
+    settings.es_base_plpmtu = @truncate(qc.max_udp_payload);
+
+    var err_buf: [256]u8 = undefined;
+    if (lsquic.lsquic_engine_check_settings(&settings, flags_eng, &err_buf, err_buf.len) != 0) {
+        return error.TlsInit;
+    }
+
+    var api = std.mem.zeroes(lsquic.lsquic_engine_api);
+    api.ea_settings = &settings;
+    api.ea_stream_if = &stream_if;
+    api.ea_stream_if_ctx = undefined;
+    api.ea_packets_out = packetsOut;
+    api.ea_packets_out_ctx = undefined;
+    api.ea_get_ssl_ctx = getSslCtx;
+    // Non-HTTP engines: lsquic stores this as `enp_alpn` (length-prefixed wire) for
+    // `esi_alpn` / application-secret ALPN verification on both client and server.
+    api.ea_alpn = alpn_cstr.ptr;
+
+    const ep = try allocator.create(QuicEndpoint);
+    errdefer allocator.destroy(ep);
+    ep.* = .{
+        .sock = sock,
+        .engine = undefined,
+        .ssl_ctx = ssl_ctx,
+        .allocator = allocator,
+        .is_server = is_server,
+        .local_addr = local_addr,
+        .resolved_local = null,
+        .accept_queue = .{},
+        .connect_slot = null,
+        .first_alpn = first_alpn,
+        .alpn_wire = alpn_wire,
+        .alpn_cstr = alpn_cstr,
+        .base_plpmtu = @truncate(qc.max_udp_payload),
+        .sni_z = null,
+        .settings = settings,
+        .api = undefined,
+    };
+    api.ea_stream_if_ctx = ep;
+    api.ea_packets_out_ctx = ep;
+    ep.api = api;
+
+    const eng = lsquic.lsquic_engine_new(flags_eng, &ep.api) orelse return error.TlsInit;
+    ep.engine = eng;
+
+    return ep;
+}
+
+pub fn endpointDeinit(ep: *QuicEndpoint) void {
+    while (ep.accept_queue.items.len > 0) {
+        const c = ep.accept_queue.swapRemove(ep.accept_queue.items.len - 1);
+        lsquic.lsquic_conn_close(c.raw);
+    }
+    ep.accept_queue.deinit(ep.allocator.*);
+    if (ep.connect_slot) |q| {
+        lsquic.lsquic_conn_close(q.raw);
+        ep.processEngine();
+    }
+    lsquic.lsquic_engine_destroy(ep.engine);
+    posix.close(ep.sock);
+    ossl.SSL_CTX_free(ep.ssl_ctx);
+    if (ep.sni_z) |s| ep.allocator.free(s);
+    ep.allocator.free(ep.alpn_wire);
+    ep.allocator.free(ep.alpn_cstr);
+    ep.allocator.destroy(ep);
+}
+
+pub fn connect(ep: *QuicEndpoint, remote_s: []const u8, hostname: []const u8) !*QuicConnection {
+    ep.connect_slot = null;
+    const remote = try parseBindAddr(remote_s);
+    if (ep.sni_z) |old| ep.allocator.free(old);
+    const hz = try ep.allocator.allocSentinel(u8, hostname.len, 0);
+    @memcpy(hz[0..hostname.len], hostname);
+    ep.sni_z = hz;
+
+    const local_sa: ?*const lsquic.struct_sockaddr = @ptrCast(@alignCast(&ep.local_addr.any));
+    const remote_sa: ?*const lsquic.struct_sockaddr = @ptrCast(@alignCast(&remote.any));
+
+    const raw_conn = lsquic.lsquic_engine_connect(
+        ep.engine,
+        lsquic.N_LSQVER,
+        local_sa,
+        remote_sa,
+        ep,
+        null,
+        hz.ptr,
+        ep.base_plpmtu,
+        null,
+        0,
+        null,
+        0,
+    ) orelse return error.ConnectFailed;
+
+    const ctx_after = lsquic.lsquic_conn_get_ctx(raw_conn);
+    const qc: *QuicConnection = if (ep.connect_slot) |s|
+        s
+    else
+        @ptrCast(@alignCast(ctx_after orelse return error.ConnectFailed));
+
+    ep.processEngine();
+
+    if (lsquic.lsquic_conn_get_ctx(raw_conn) == null) return error.ConnectFailed;
+    return qc;
+}
+
+pub fn destroy(ep: *QuicEndpoint, conn: *QuicConnection) void {
+    lsquic.lsquic_conn_close(conn.raw);
+    ep.processEngine();
+}
+
+pub fn poll(ep: *QuicEndpoint, timeout_ms: u32) !void {
+    if (try ep.waitReadable(timeout_ms)) {
+        while (try ep.recvOneIfAvailable()) {}
+    }
+    ep.processEngine();
+}
+
+pub fn tryAccept(ep: *QuicEndpoint) ?*QuicConnection {
+    if (ep.accept_queue.items.len == 0) return null;
+    return ep.accept_queue.swapRemove(0);
+}
+
+pub fn handshakeComplete(conn: *const QuicConnection) bool {
+    return conn.hsk_ok;
+}
+
+pub fn getNegotiatedAlpn(conn: *const QuicConnection) ?[]const u8 {
+    if (!conn.hsk_ok) return null;
+    return conn.ep.first_alpn;
+}

--- a/src/transport/lsquic_quic_shim.zig
+++ b/src/transport/lsquic_quic_shim.zig
@@ -18,9 +18,53 @@ const ossl = @cImport({
 var g_lsquic_global: bool = false;
 var g_alpn_selected_buf: [128]u8 = undefined;
 
+/// When true, first few `lsquic_engine_packet_in` calls print ret/len/role to stderr (see env below).
+var g_trace_packet_in: bool = false;
+var g_packet_in_trace_count: u32 = 0;
+
+fn lsquicShimLogBuf(_: ?*anyopaque, buf: [*c]const u8, len: usize) callconv(.c) c_int {
+    if (len == 0) return 0;
+    _ = posix.write(posix.STDERR_FILENO, buf[0..len]) catch return -1;
+    return 0;
+}
+
+const g_lsquic_stderr_logger_if: lsquic.lsquic_logger_if = .{
+    .log_buf = lsquicShimLogBuf,
+};
+
+fn maybeInitLsquicStderrLogger() void {
+    const want_log = posix.getenv("LSQUIC_LOG_LEVEL") != null or
+        posix.getenv("LSQUIC_LOGGERLOPT") != null or blk: {
+        const z = posix.getenv("ZIG_ETHP2P_LSQUIC_LOG") orelse break :blk false;
+        break :blk z.len > 0 and !std.mem.eql(u8, z, "0");
+    };
+    if (!want_log) return;
+
+    lsquic.lsquic_logger_init(&g_lsquic_stderr_logger_if, null, lsquic.LLTS_NONE);
+    g_trace_packet_in = true;
+
+    if (posix.getenv("LSQUIC_LOGGERLOPT")) |raw| {
+        var stack: [512]u8 = undefined;
+        if (raw.len >= stack.len) return;
+        @memcpy(stack[0..raw.len], raw);
+        stack[raw.len] = 0;
+        _ = lsquic.lsquic_logger_lopt(@ptrCast(&stack));
+        return;
+    }
+
+    const raw_level = posix.getenv("LSQUIC_LOG_LEVEL") orelse (posix.getenv("ZIG_ETHP2P_LSQUIC_LOG") orelse "debug");
+    const use_level: []const u8 = if (std.mem.eql(u8, raw_level, "1")) "debug" else raw_level;
+    var level_buf: [96]u8 = undefined;
+    if (use_level.len >= level_buf.len) return;
+    @memcpy(level_buf[0..use_level.len], use_level);
+    level_buf[use_level.len] = 0;
+    _ = lsquic.lsquic_set_log_level(@ptrCast(&level_buf));
+}
+
 fn ensureLsquicGlobal() void {
     if (g_lsquic_global) return;
     _ = lsquic.lsquic_global_init(lsquic.LSQUIC_GLOBAL_CLIENT | lsquic.LSQUIC_GLOBAL_SERVER);
+    maybeInitLsquicStderrLogger();
     g_lsquic_global = true;
 }
 
@@ -134,7 +178,7 @@ pub const QuicEndpoint = struct {
             break :blk @ptrCast(@alignCast(&self.local_addr.any));
         };
 
-        _ = lsquic.lsquic_engine_packet_in(
+        const pin_ret = lsquic.lsquic_engine_packet_in(
             self.engine,
             buf[0..@intCast(n)].ptr,
             @intCast(n),
@@ -143,6 +187,17 @@ pub const QuicEndpoint = struct {
             self,
             0,
         );
+        if (g_trace_packet_in) {
+            const c = g_packet_in_trace_count;
+            if (c < 32) {
+                g_packet_in_trace_count = c + 1;
+                std.debug.print("zig-ethp2p lsquic_engine_packet_in: ret={d} len={d} server={any}\n", .{
+                    pin_ret,
+                    n,
+                    self.is_server,
+                });
+            }
+        }
         self.processEngine();
         return true;
     }
@@ -238,6 +293,23 @@ fn makeSslCtxClient(allow_insecure: bool, alpn_wire: []const u8) !*ossl.SSL_CTX 
     if (ossl.SSL_CTX_set_min_proto_version(ctx, ossl.TLS1_3_VERSION) == 0) return error.TlsInit;
     if (ossl.SSL_CTX_set_max_proto_version(ctx, ossl.TLS1_3_VERSION) == 0) return error.TlsInit;
     _ = ossl.SSL_CTX_set_default_verify_paths(ctx);
+
+    // BoringSSL's default TLS 1.3 ClientHello omits Ed25519. A server certificate
+    // signed with Ed25519 then fails with TLS alert 40 (handshake_failure).
+    const verify_prefs = [_]u16{
+        ossl.SSL_SIGN_ED25519,
+        ossl.SSL_SIGN_ECDSA_SECP256R1_SHA256,
+        ossl.SSL_SIGN_ECDSA_SECP384R1_SHA384,
+        ossl.SSL_SIGN_ECDSA_SECP521R1_SHA512,
+        ossl.SSL_SIGN_RSA_PKCS1_SHA256,
+        ossl.SSL_SIGN_RSA_PKCS1_SHA384,
+        ossl.SSL_SIGN_RSA_PKCS1_SHA512,
+        ossl.SSL_SIGN_RSA_PSS_RSAE_SHA256,
+        ossl.SSL_SIGN_RSA_PSS_RSAE_SHA384,
+        ossl.SSL_SIGN_RSA_PSS_RSAE_SHA512,
+    };
+    if (ossl.SSL_CTX_set_verify_algorithm_prefs(ctx, &verify_prefs, verify_prefs.len) == 0)
+        return error.TlsInit;
 
     if (ossl.SSL_CTX_set_alpn_protos(ctx, alpn_wire.ptr, @intCast(alpn_wire.len)) != 0) return error.TlsInit;
 
@@ -404,6 +476,9 @@ pub fn endpointInit(allocator: *std.mem.Allocator, bind_s: []const u8, qc: *Quic
     var settings: lsquic.lsquic_engine_settings = undefined;
     lsquic.lsquic_engine_init_settings(&settings, flags_eng);
     settings.es_versions = lsquic.LSQUIC_IETF_VERSIONS;
+    // Avoid AL_IDLE "lack of progress" while a connection is still completing setup
+    // (common when the app drives the engine in a tight loop).
+    settings.es_noprogress_timeout = 0;
     if (is_server) {
         // Default server `es_support_srej` issues Retry on tokenless Initials; that path
         // can strand the handshake for loopback tests that expect a single mini→full flow.

--- a/src/transport/lsquic_quic_shim.zig
+++ b/src/transport/lsquic_quic_shim.zig
@@ -601,6 +601,20 @@ pub fn poll(ep: *QuicEndpoint, timeout_ms: u32) !void {
         while (try ep.recvOneIfAvailable()) {}
     }
     ep.processEngine();
+    // `timeout_ms == 0` is used in tight loops; without a wall-clock nudge, lsquic's
+    // advisory timers (PTO, etc.) may never elapse. Use the engine hint when present,
+    // otherwise sleep briefly so multi-engine handshakes still make progress.
+    if (timeout_ms == 0) {
+        var diff_us: c_int = 0;
+        const has_tick = lsquic.lsquic_engine_earliest_adv_tick(ep.engine, &diff_us) != 0;
+        // Cap per call so tight loops (e.g. tests) do not sleep tens of ms per poll;
+        // many iterations still accumulate enough wall time for PTO-sized delays.
+        var sleep_us: u64 = 50;
+        if (has_tick and diff_us > 0) {
+            sleep_us = @min(@as(u64, @intCast(diff_us)), 500);
+        }
+        std.Thread.sleep(sleep_us * std.time.ns_per_us);
+    }
 }
 
 pub fn tryAccept(ep: *QuicEndpoint) ?*QuicConnection {
@@ -608,11 +622,20 @@ pub fn tryAccept(ep: *QuicEndpoint) ?*QuicConnection {
     return ep.accept_queue.swapRemove(0);
 }
 
+fn connHandshakeReady(conn: *const QuicConnection) bool {
+    if (conn.hsk_ok) return true;
+    // lsquic sometimes completes the TLS+QUIC handshake without invoking `on_hsk_done`
+    // with `LSQ_HSK_OK` on the server side; `lsquic_conn_status` reflects readiness.
+    var errscratch: [1]u8 = undefined;
+    const st = lsquic.lsquic_conn_status(conn.raw, @ptrCast(&errscratch), errscratch.len);
+    return st == @as(lsquic.enum_LSQUIC_CONN_STATUS, @intCast(lsquic.LSCONN_ST_CONNECTED));
+}
+
 pub fn handshakeComplete(conn: *const QuicConnection) bool {
-    return conn.hsk_ok;
+    return connHandshakeReady(conn);
 }
 
 pub fn getNegotiatedAlpn(conn: *const QuicConnection) ?[]const u8 {
-    if (!conn.hsk_ok) return null;
+    if (!connHandshakeReady(conn)) return null;
     return conn.ep.first_alpn;
 }

--- a/vendor/lsquic_zig/build.zig
+++ b/vendor/lsquic_zig/build.zig
@@ -1,0 +1,214 @@
+const std = @import("std");
+
+pub fn build(b: *std.Build) void {
+    const target = b.standardTargetOptions(.{});
+    const optimize = b.standardOptimizeOption(.{});
+
+    const upstream = b.dependency("lsquic", .{
+        .target = target,
+        .optimize = optimize,
+    });
+    const boringssl = b.dependency("boringssl", .{
+        .target = target,
+        .optimize = optimize,
+    });
+    const lshpack_dep = b.dependency("lshpack", .{
+        .target = target,
+        .optimize = optimize,
+    });
+    const lsqpack_dep = b.dependency("lsqpack", .{
+        .target = target,
+        .optimize = optimize,
+    });
+
+    const ssl = boringssl.artifact("ssl");
+    const crypto = boringssl.artifact("crypto");
+
+    const lib = b.addLibrary(.{
+        .name = "lsquic",
+        .linkage = .static,
+
+        .root_module = b.createModule(
+            .{
+                .target = target,
+                .optimize = optimize,
+                .link_libc = true,
+            },
+        ),
+    });
+
+    var c_flags: std.ArrayList([]const u8) = .empty;
+
+    c_flags.appendSlice(b.allocator, &.{
+        "-DLSQUIC_DEBUG_NEXT_ADV_TICK=1",
+        "-DLSQUIC_CONN_STATS=1",
+        "-DLSQUIC_DEVEL=1",
+        "-DLSQUIC_WEBTRANSPORT_SERVER_SUPPORT=1",
+        // When using the Zig ReleaseSafe mode, it seems force to check for undefined behavior.
+        // This is not the case with ReleaseSmall or ReleaseFast. So we must add this flag
+        // to avoid the build failing with ReleaseSafe.
+        "-fno-sanitize=undefined",
+    }) catch @panic("OOM");
+
+    if (optimize == .Debug) {
+        c_flags.appendSlice(b.allocator, &.{ "-O0", "-g3" }) catch @panic("OOM");
+    } else {
+        c_flags.appendSlice(b.allocator, &.{ "-O3", "-g0" }) catch @panic("OOM");
+    }
+
+    if (target.result.os.tag == .windows) {
+        // When we have a windows test environment, we can enable these flags.
+        // lib.addIncludePath(upstream.path("wincompat"));
+        // c_flags.appendSlice(&.{
+        //     "/W4",                       "/WX",
+        //     "-DWIN32_LEAN_AND_MEAN",     "-DNOMINMAX",
+        //     "-D_CRT_SECURE_NO_WARNINGS", "/wd4100",
+        //     "/wd4115",                   "/wd4116",
+        //     "/wd4146",                   "/wd4132",
+        //     "/wd4200",                   "/wd4204",
+        //     "/wd4244",                   "/wd4245",
+        //     "/wd4267",                   "/wd4214",
+        //     "/wd4295",                   "/wd4324",
+        //     "/wd4334",                   "/wd4456",
+        //     "/wd4459",                   "/wd4706",
+        //     "/wd4090",                   "/wd4305",
+        // }) catch @panic("OOM");
+    } else {
+        c_flags.appendSlice(b.allocator, &.{
+            // Lifted from lsquic's CMakeLists.txt
+            // Source: https://github.com/litespeedtech/lsquic/blob/70486141724f85e97b08f510673e29f399bbae8f/CMakeLists.txt#L52-L53
+            "-Wall",
+            "-Wextra",
+            "-Wno-unused-parameter",
+            "-fno-omit-frame-pointer",
+        }) catch @panic("OOM");
+    }
+
+    // --- Linking and Paths ---
+    lib.linkLibC();
+    lib.linkLibrary(ssl);
+    lib.linkLibrary(crypto);
+
+    if (target.result.os.tag == .windows) {
+        // Uncomment these when we have a windows test environment.
+        // lib.linkSystemLibrary("ws2_32");
+    } else {
+        lib.linkSystemLibrary("m");
+        lib.linkSystemLibrary("pthread");
+    }
+
+    lib.addIncludePath(upstream.path("include"));
+    lib.addIncludePath(lshpack_dep.path(""));
+    lib.addIncludePath(lsqpack_dep.path(""));
+    lib.addIncludePath(lshpack_dep.path("deps/xxhash"));
+
+    lib.installHeadersDirectory(
+        upstream.path("include"),
+        "",
+        .{ .include_extensions = &.{".h"} },
+    );
+    lib.installHeader(lsqpack_dep.path("lsqpack.h"), "lsqpack/lsqpack.h");
+    lib.installHeader(lshpack_dep.path("lshpack.h"), "lshpack/lshpack.h");
+    lib.installHeader(lshpack_dep.path("deps/xxhash/xxhash.h"), "xxhash.h");
+    lib.root_module.addCMacro("XXH_HEADER_NAME", "\"xxhash.h\"");
+
+    lib.addCSourceFiles(.{
+        .root = upstream.path("src/liblsquic"),
+        .files = lsquic_files,
+        .flags = c_flags.items,
+    });
+    lib.addCSourceFile(.{ .file = lsqpack_dep.path("lsqpack.c"), .flags = c_flags.items });
+    lib.addCSourceFile(.{ .file = lshpack_dep.path("lshpack.c"), .flags = c_flags.items });
+    lib.addCSourceFile(.{ .file = lshpack_dep.path("deps/xxhash/xxhash.c"), .flags = c_flags.items });
+
+    b.installArtifact(lib);
+
+    const test_step = b.step("test", "Run unit tests");
+    _ = test_step;
+}
+
+const lsquic_files: []const []const u8 = &.{
+    "ls-sfparser.c",
+    "lsquic_adaptive_cc.c",
+    "lsquic_alarmset.c",
+    "lsquic_arr.c",
+    "lsquic_attq.c",
+    "lsquic_bbr.c",
+    "lsquic_bw_sampler.c",
+    "lsquic_cfcw.c",
+    "lsquic_chsk_stream.c",
+    "lsquic_conn.c",
+    "lsquic_crand.c",
+    "lsquic_crt_compress.c",
+    "lsquic_crypto.c",
+    "lsquic_cubic.c",
+    "lsquic_di_error.c",
+    "lsquic_di_hash.c",
+    "lsquic_di_nocopy.c",
+    "lsquic_enc_sess_common.c",
+    "lsquic_enc_sess_ietf.c",
+    "lsquic_eng_hist.c",
+    "lsquic_engine.c",
+    "lsquic_ev_log.c",
+    "lsquic_frab_list.c",
+    "lsquic_frame_common.c",
+    "lsquic_frame_reader.c",
+    "lsquic_frame_writer.c",
+    "lsquic_full_conn.c",
+    "lsquic_full_conn_ietf.c",
+    "lsquic_global.c",
+    "lsquic_handshake.c",
+    "lsquic_hash.c",
+    "lsquic_hcsi_reader.c",
+    "lsquic_hcso_writer.c",
+    "lsquic_headers_stream.c",
+    "lsquic_hkdf.c",
+    "lsquic_hpi.c",
+    "lsquic_hspack_valid.c",
+    "lsquic_http.c",
+    "lsquic_http1x_if.c",
+    "lsquic_logger.c",
+    "lsquic_malo.c",
+    "lsquic_min_heap.c",
+    "lsquic_mini_conn.c",
+    "lsquic_mini_conn_ietf.c",
+    "lsquic_minmax.c",
+    "lsquic_mm.c",
+    "lsquic_pacer.c",
+    "lsquic_packet_common.c",
+    "lsquic_packet_gquic.c",
+    "lsquic_packet_in.c",
+    "lsquic_packet_out.c",
+    "lsquic_packet_resize.c",
+    "lsquic_parse_Q046.c",
+    "lsquic_parse_Q050.c",
+    "lsquic_parse_common.c",
+    "lsquic_parse_gquic_be.c",
+    "lsquic_parse_gquic_common.c",
+    "lsquic_parse_ietf_v1.c",
+    "lsquic_parse_iquic_common.c",
+    "lsquic_pr_queue.c",
+    "lsquic_purga.c",
+    "lsquic_qdec_hdl.c",
+    "lsquic_qenc_hdl.c",
+    "lsquic_qlog.c",
+    "lsquic_qpack_exp.c",
+    "lsquic_rechist.c",
+    "lsquic_rtt.c",
+    "lsquic_send_ctl.c",
+    "lsquic_senhist.c",
+    "lsquic_set.c",
+    "lsquic_sfcw.c",
+    "lsquic_shsk_stream.c",
+    "lsquic_spi.c",
+    "lsquic_stock_shi.c",
+    "lsquic_str.c",
+    "lsquic_stream.c",
+    "lsquic_tokgen.c",
+    "lsquic_trans_params.c",
+    "lsquic_trechist.c",
+    "lsquic_util.c",
+    "lsquic_varint.c",
+    "lsquic_version.c",
+    "lsquic_xxhash.c",
+};

--- a/vendor/lsquic_zig/build.zig.zon
+++ b/vendor/lsquic_zig/build.zig.zon
@@ -1,0 +1,36 @@
+.{
+    .name = .lsquic,
+
+    .version = "0.0.0",
+    .fingerprint = 0x91bb79d376e0ee8c,
+    .minimum_zig_version = "0.15.0",
+
+    .dependencies = .{
+        .lsquic = .{
+            .url = "git+https://github.com/litespeedtech/lsquic#aecfcefa422505929ba29071442785a884571126",
+            .hash = "N-V-__8AAALQZACNAeMe8qEYieQId_sO9YzLbIyJyVwryHz_",
+        },
+        .boringssl = .{
+            .url = "git+https://github.com/Syndica/boringssl-zig#c53df00d06b02b755ad88bbf4d1202ed9687b096",
+            .hash = "boringssl-0.1.0-VtJeWehMAAA4RNnwRnzEvKcS9rjsR1QVRw1uJrwXxmVK",
+        },
+        .zlib = .{
+            .url = "git+https://github.com/allyourcodebase/zlib#c5115f4b69ef660f72a835c6638f80508ef284c7",
+            .hash = "zlib-1.3.1-1-ZZQ7ldENAAA7qJjUXP6E6xnRuV-jDL9dyoJFc_eb3zQ6",
+        },
+        .lshpack = .{
+            .url = "git+https://github.com/litespeedtech/ls-hpack#8905c024b6d052f083a3d11d0a169b3c2735c8a1",
+            .hash = "N-V-__8AAFo5VQCMGNos53oUbtdyzgRTdBedy52h5FsecO51",
+        },
+        .lsqpack = .{
+            .url = "git+https://github.com/litespeedtech/ls-qpack#1e9c5b8e59f8161c54f168a570c8bfdc59ded0c3",
+            .hash = "N-V-__8AAKHvVgBsNJVDKKVAFfD0XLyv3NZA7q19Lkm6ozff",
+        },
+    },
+
+    .paths = .{
+        "build.zig",
+        "build.zig.zon",
+        "src",
+    },
+}


### PR DESCRIPTION
## Summary

Moves QUIC to the in-repo **lsquic** + **BoringSSL** stack (`-Denable-quic`) instead of the prior devnw-based direction in #32. Please **close #32** once this approach is accepted.

## Notes

- Shim: `src/transport/lsquic_quic_shim.zig` (listen/dial, TLS 1.3, ALPN).
- Handshake driving: `poll(..., 0)` nudges wall clock from `lsquic_engine_earliest_adv_tick`; `handshakeComplete` also treats `lsquic_conn_status == LSCONN_ST_CONNECTED` when `on_hsk_done` does not set OK on the server path.
- **CI:** `quic-transport` job has a 45m job cap and `timeout 40m` on the build so a hung test cannot exhaust the runner.

## Checklist

- [ ] CI green (including `quic-transport`)
- [ ] Remove or redirect duplicate QUIC PR (#32)
