### PR TITLE
transport: UNI stream alignment with ethp2p reference (issue #28)

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ Zig helpers for the wire formats of **[ethp2p](https://github.com/ethp2p/ethp2p)
 | Unsigned-varint length prefix before `RPC` body | common libp2p framing | `encodeRpcLengthPrefixed`, `decodeRpcLengthPrefixedPrefix` |
 | In-process duplex for length-prefixed `RPC` (simnet-style, no TCP/QUIC) | pair of `Endpoint`s over bounded byte queues | `sim.gossipsub_rpc_host` (`Link`, `Endpoint.sendRpc` / `recvRpcOwned`) |
 | QUIC transport | [`sim/host.go`](https://github.com/ethp2p/ethp2p/blob/main/sim/host.go) `QUICHost`, `defaultQuicConfig` | `transport.eth_ec_quic`: default build = ALPN + config + UDP bind smoke only (`listen` / `dial` → `error.TransportNotImplemented`). **`-Denable-quic`** links **lsquic + BoringSSL** (`vendor/lsquic_zig`, shim `lsquic_quic_shim.zig`): IETF QUIC, TLS 1.3, ALPN `eth-ec-broadcast`, `listen` / `dial`, CI handshake test. See [QUIC transport](#quic-transport-optional-lsquic-build). |
+| QUIC UNI stream alignment | `peer.go` `handshake()`, `peer_ctrl.go` `handleSessionOpen`/`doSendChunk`, `peer_in.go` `runAcceptLoop` | `lsquic_quic_shim.zig` `streamMakeUni`/`tryAcceptIncomingUniStream`; vendor patch exposes `lsquic_conn_make_uni_stream` (see `vendor/lsquic_zig/patch_uni.sh` and `lsquic_ethp2p_ext.h`); `eth_ec_quic_peer.zig` `PeerConn` lifecycle sketch |
 | **Still open** | — | [Pending work](#pending-work) |
 
 ## Scope on `main` (at a glance)
@@ -86,15 +87,27 @@ Callers must **drive the engine**: after I/O, use **`quic.poll(endpoint, timeout
 
 Set **`ZIG_ETHP2P_LSQUIC_LOG=1`** (or standard **`LSQUIC_LOG_LEVEL`**) to initialize lsquic’s stderr logger and optional packet-in tracing (see shim).
 
+**UNI stream alignment (issue #28)**
+
+All ethp2p application protocols (BCAST, SESS, CHUNK) use **unidirectional** QUIC streams, matching `peer.go` `OpenUniStream`/`AcceptUniStream`. The shim now exposes:
+
+- `streamMakeUni` — open an outgoing UNI send stream (wraps patched `lsquic_conn_make_uni_stream`; see `vendor/lsquic_zig/patch_uni.sh`)
+- `tryAcceptIncomingUniStream` — pop the next peer-initiated UNI stream
+- `on_reset` callback records stream resets in `QuicStream.reset_how`
+- `streamCancelWrite` / `streamCancelRead` — close-side teardown
+- `eth_ec_quic_peer.zig` — `PeerConn` poll-driven state machine sketch (handshake + accept-loop)
+
+**lsquic vendor patch**: lsquic 4.3 has no public API for outgoing UNI streams. `vendor/lsquic_zig/build.zig` runs `patch_uni.sh` at build time, which removes `static` from `create_uni_stream_out` in a copy of `lsquic_full_conn_ietf.c` and appends a public `lsquic_conn_make_uni_stream()` wrapper. The upstream file is untouched.
+
 **Still open**
 
-QUIC **streams are not wired** to `wire.*` / broadcast sessions yet (see `eth_ec_quic.zig` and issue **#27**). Production **libp2p** integration remains separate from this stack.
+`PeerConn` is not yet wired to `Engine`/channel tables — that is follow-up work. Production **libp2p** integration (Noise, multistream-select, Yamux, identify) is separate from this stack; zeam handles that layer via **rust-libp2p**.
 
 ## Pending work
 
 What is **not** covered yet (the [implementation table](#implementation-status-vs-reference) remains authoritative for details):
 
-- **Transport:** QUIC **streams** plumbed into BCAST/SESS/CHUNK (`wire.*`) and production **libp2p** — the **lsquic + BoringSSL** path handles listen/dial and handshake when built with **`-Denable-quic`**; see [QUIC transport](#quic-transport-optional-lsquic-build).
+- **Transport:** `PeerConn` wired to `Engine`/channel tables; production **libp2p** (Noise, multistream-select, Yamux) is handled by zeam's rust-libp2p layer and is out of scope here. UNI stream alignment with `peer.go`/`peer_ctrl.go`/`peer_in.go` is done (see [QUIC UNI stream alignment](#quic-transport-optional-lsquic-build)).
 - **Gossipsub `RPC`:** protobuf extension fields beyond **`partial`** / `PartialMessagesExtension` (field 10).
 - **Erasure coding:** `layer.ec_scheme` holds the scheme enum and `"reed-solomon"` wire name; **RLNC** (strategy, preamble, chunk layout) and any further `Scheme` types remain ([#14](https://github.com/ch4r10t33r/zig-ethp2p/issues/14)).
 - **Engine:** optional channel-style event loop / `VerdictPending` for non-RS schemes.
@@ -104,8 +117,7 @@ What is **not** covered yet (the [implementation table](#implementation-status-v
 | Issue | Topic |
 |-------|-------|
 | [#14](https://github.com/ch4r10t33r/zig-ethp2p/issues/14) | RLNC + additional EC schemes (beyond `layer.ec_scheme` scaffold) |
-| [#26](https://github.com/ch4r10t33r/zig-ethp2p/issues/26) | QUIC transport integration (lsquic + BoringSSL; listen/dial; CI `quic-transport`) |
-| [#27](https://github.com/ch4r10t33r/zig-ethp2p/issues/27) | Map BCAST / SESS / CHUNK to QUIC streams (`wire.*`) |
+| [#14](https://github.com/ch4r10t33r/zig-ethp2p/issues/14) | RLNC + additional EC schemes (beyond `layer.ec_scheme` scaffold) |
 
 ## Requirements
 

--- a/UPSTREAM.md
+++ b/UPSTREAM.md
@@ -28,6 +28,14 @@ When updating:
 
 `src/transport/eth_ec_quic.zig` mirrors **ALPN** `eth-ec-broadcast` and high-level **quic-go-style** limits from ethp2p `sim/host.go`. With **`-Denable-quic`**, lsquic + BoringSSL is linked via `vendor/lsquic_zig`.
 
+### Why raw QUIC and why unidirectional streams
+
+**Why raw QUIC?** Direct access to QUIC's built-in multiplexing, per-stream flow control, congestion control, and RTT measurements — without adding another framing layer.
+
+**Why unidirectional streams?** P2P protocols have no client/server notion; both peers are equal and can try to open a stream to each other simultaneously. With bidirectional streams that creates a *simultaneous open* ambiguity that must be resolved in-band. Unidirectional streams eliminate the ambiguity by design: each peer opens its own send stream independently, and there is no question about which side "owns" the stream. Opening streams in QUIC is cheap (no extra round-trip), so the cost of using two half-streams instead of one full-stream is negligible.
+
+Bidirectional streams are viable when the protocol has a clear initiator (e.g. HTTP, where only the client opens streams). ethp2p deliberately chose UNI streams to keep the peer state machine stateless with respect to stream negotiation.
+
 ### UNI stream alignment (issue #28)
 
 The ethp2p reference uses **unidirectional** QUIC streams for all application protocols:

--- a/UPSTREAM.md
+++ b/UPSTREAM.md
@@ -26,7 +26,36 @@ When updating:
 
 ## QUIC / UDP transport
 
-`src/transport/eth_ec_quic.zig` mirrors **ALPN** `eth-ec-broadcast` and high-level **quic-go-style** limits from ethp2p `sim/host.go`. It does not link a QUIC implementation yet; integrating something like [`gitlab.com/devnw/zig/quic`](https://gitlab.com/devnw/zig/quic) implies extra system libs (e.g. OpenSSL on Linux/macOS in that tree), likely Zig **0.15.1+**, and CI image updates—prefer an opt-in `build.zig` step until stable.
+`src/transport/eth_ec_quic.zig` mirrors **ALPN** `eth-ec-broadcast` and high-level **quic-go-style** limits from ethp2p `sim/host.go`. With **`-Denable-quic`**, lsquic + BoringSSL is linked via `vendor/lsquic_zig`.
+
+### UNI stream alignment (issue #28)
+
+The ethp2p reference uses **unidirectional** QUIC streams for all application protocols:
+
+- `peer.go` `handshake()`: both sides call `conn.OpenUniStream()` for the BCAST control stream (IDs 2/3, 6/7, …)
+- `peer_ctrl.go` `handleSessionOpen`, `doSendChunk`: `conn.OpenUniStream()` for SESS and CHUNK streams
+- `peer_in.go` `runAcceptLoop`: `conn.AcceptUniStream()` for all inbound streams
+
+Zig alignment:
+
+- `lsquic_quic_shim.zig` detects stream type via `lsquic_stream_id() & 0x2` (bit 1 = unidirectional per RFC 9000 §2.1)
+- `incoming_uni_streams` queue holds peer-initiated UNI streams; `tryAcceptIncomingUniStream` pops them
+- `streamMakeUni` opens an outgoing UNI stream via `lsquic_conn_make_uni_stream`
+- `eth_ec_quic_peer.zig` sketches the `PeerConn` poll-driven state machine (handshake + accept-loop)
+
+### lsquic vendor patch
+
+lsquic 4.3 has no public API for user-initiated outgoing unidirectional streams (`lsquic_conn_make_stream` always creates bidirectional streams). The internal `create_uni_stream_out` function in `lsquic_full_conn_ietf.c` is `static`.
+
+Fix: `vendor/lsquic_zig/build.zig` runs `vendor/lsquic_zig/patch_uni.sh` as a build step. The script:
+1. Removes `static` from `create_uni_stream_out` in a patched copy of `lsquic_full_conn_ietf.c`
+2. Appends a public `lsquic_conn_make_uni_stream(lsquic_conn_t *)` wrapper at the end of the file
+
+The public declaration lives in `vendor/lsquic_zig/lsquic_ethp2p_ext.h`. The upstream source file is untouched.
+
+### libp2p boundary
+
+The ethp2p `sim/` QUIC transport is illustrative. Production deployments layer **libp2p** on top (Noise handshake, multistream-select, Yamux multiplexer, identify protocol). That layer is out of scope for `zig-ethp2p`; zeam handles it via **rust-libp2p**.
 
 ## EC schemes (issue [#14](https://github.com/ch4r10t33r/zig-ethp2p/issues/14))
 

--- a/build.zig
+++ b/build.zig
@@ -32,6 +32,8 @@ fn addLsquicQuicModule(
     });
     quic_mod.addIncludePath(lsquic_upstream.path("include"));
     quic_mod.addIncludePath(openssl_src.path("include"));
+    // zig-ethp2p extension header (lsquic_ethp2p_ext.h) lives alongside the vendor build.zig.
+    quic_mod.addIncludePath(b.path("vendor/lsquic_zig"));
 
     return .{
         .quic_mod = quic_mod,

--- a/src/transport/eth_ec_quic_enabled.zig
+++ b/src/transport/eth_ec_quic_enabled.zig
@@ -22,6 +22,20 @@ fn acceptIncomingQuicStream(
     return error.QuicAcceptStreamTimeout;
 }
 
+fn acceptIncomingQuicUniStream(
+    conn: *quic.QuicConnection,
+    local: *quic.QuicEndpoint,
+    peer: *quic.QuicEndpoint,
+) anyerror!*quic.QuicStream {
+    var budget: u32 = 10_000;
+    while (budget > 0) : (budget -= 1) {
+        if (quic.tryAcceptIncomingUniStream(conn)) |st| return st;
+        try quic.poll(local, 0);
+        try quic.poll(peer, 0);
+    }
+    return error.QuicAcceptUniStreamTimeout;
+}
+
 fn waitQuicStreamBytes(
     st: *quic.QuicStream,
     local: *quic.QuicEndpoint,
@@ -190,7 +204,12 @@ test "QUIC listen + dial, TLS handshake, ALPN eth-ec-broadcast" {
     quic.destroy(client_ep, conn);
 }
 
-test "QUIC streams: BCAST handshake then SESS session_open (wire framing)" {
+// Matches the symmetric BCAST handshake in peer.go:
+//   Both sides concurrently call OpenUniStream() and write PROTOCOL_BCAST + Handshake.
+//   Both sides concurrently call AcceptUniStream() to receive the peer's stream.
+// In Zig's poll-driven model we do this sequentially but interleave both sides before
+// any reads so neither blocks waiting for the other.
+test "QUIC UNI streams: symmetric BCAST handshake + SESS session_open (wire framing)" {
     if (@import("builtin").os.tag == .windows) return error.SkipZigTest;
     if (@import("builtin").os.tag == .wasi) return error.SkipZigTest;
 
@@ -242,38 +261,62 @@ test "QUIC streams: BCAST handshake then SESS session_open (wire framing)" {
     while (rounds < 30_000) : (rounds += 1) {
         try quic.poll(srv, 0);
         try quic.poll(client_ep, 0);
-        if (server_conn == null) {
-            server_conn = quic.tryAccept(srv);
-        }
+        if (server_conn == null) server_conn = quic.tryAccept(srv);
         if (quic.handshakeComplete(conn)) {
             if (server_conn) |sc| {
                 if (quic.handshakeComplete(sc)) break;
             }
         }
     }
-
     const sc = server_conn orelse return error.MissingServerConnection;
     try std.testing.expect(quic.handshakeComplete(conn));
     try std.testing.expect(quic.handshakeComplete(sc));
 
-    const cli_bcast = try quic.streamMake(conn, srv);
-    var bcast_payload = std.ArrayList(u8).empty;
-    defer bcast_payload.deinit(alloc);
+    // --- BCAST symmetric handshake (UNI streams) ---
+    // Both sides open their outbound BCAST UNI stream before either reads,
+    // matching peer.go's concurrent goroutine pattern.
+
+    const cli_bcast_out = try quic.streamMakeUni(conn, srv);
+    const srv_bcast_out = try quic.streamMakeUni(sc, client_ep);
+
+    var cli_bcast_payload = std.ArrayList(u8).empty;
+    defer cli_bcast_payload.deinit(alloc);
     {
-        const w = bcast_payload.writer(alloc);
+        const w = cli_bcast_payload.writer(alloc);
         try bcast_stream.writeBcastHandshakeOpen(w, alloc, .{
             .version = 1,
             .channels = &.{ "blocks", "atts" },
-            .peer_id = "peer1",
+            .peer_id = "client-peer",
         });
     }
-    try quic.streamQueueWrite(cli_bcast, bcast_payload.items);
-    try quic.streamDrainWrites(cli_bcast, srv, 10_000);
+    try quic.streamQueueWrite(cli_bcast_out, cli_bcast_payload.items);
+    try quic.streamDrainWrites(cli_bcast_out, srv, 10_000);
 
-    const srv_bcast = try acceptIncomingQuicStream(sc, srv, client_ep);
-    try waitQuicStreamBytes(srv_bcast, srv, client_ep, bcast_payload.items.len, 10_000);
-    try std.testing.expectEqualSlices(u8, bcast_payload.items, quic.streamReadSlice(srv_bcast));
-    const bcast_copy = try alloc.dupe(u8, quic.streamReadSlice(srv_bcast));
+    var srv_bcast_payload = std.ArrayList(u8).empty;
+    defer srv_bcast_payload.deinit(alloc);
+    {
+        const w = srv_bcast_payload.writer(alloc);
+        try bcast_stream.writeBcastHandshakeOpen(w, alloc, .{
+            .version = 1,
+            .channels = &.{"chunks"},
+            .peer_id = "server-peer",
+        });
+    }
+    try quic.streamQueueWrite(srv_bcast_out, srv_bcast_payload.items);
+    try quic.streamDrainWrites(srv_bcast_out, client_ep, 10_000);
+
+    // Accept the peer's inbound BCAST UNI stream on each side.
+    const srv_bcast_in = try acceptIncomingQuicUniStream(sc, srv, client_ep);
+    const cli_bcast_in = try acceptIncomingQuicUniStream(conn, client_ep, srv);
+
+    try waitQuicStreamBytes(srv_bcast_in, srv, client_ep, cli_bcast_payload.items.len, 10_000);
+    try waitQuicStreamBytes(cli_bcast_in, client_ep, srv, srv_bcast_payload.items.len, 10_000);
+
+    try std.testing.expectEqualSlices(u8, cli_bcast_payload.items, quic.streamReadSlice(srv_bcast_in));
+    try std.testing.expectEqualSlices(u8, srv_bcast_payload.items, quic.streamReadSlice(cli_bcast_in));
+
+    // Decode the client's BCAST handshake as seen by the server.
+    const bcast_copy = try alloc.dupe(u8, quic.streamReadSlice(srv_bcast_in));
     defer alloc.free(bcast_copy);
     var bcast_fbs = std.io.fixedBufferStream(bcast_copy);
     var hs_owned = try bcast_stream.readBcastPeerHandshake(alloc, bcast_fbs.reader());
@@ -281,12 +324,14 @@ test "QUIC streams: BCAST handshake then SESS session_open (wire framing)" {
     switch (hs_owned) {
         .peer_handshake => |h| {
             try std.testing.expectEqual(@as(u32, 1), h.version);
-            try std.testing.expectEqualStrings("peer1", h.peer_id);
+            try std.testing.expectEqualStrings("client-peer", h.peer_id);
         },
         else => unreachable,
     }
 
-    const cli_sess = try quic.streamMake(conn, srv);
+    // --- SESS UNI stream (peer_ctrl.go handleSessionOpen) ---
+    // Client opens a SESS UNI stream and writes session_open.
+    const cli_sess = try quic.streamMakeUni(conn, srv);
     var sess_payload = std.ArrayList(u8).empty;
     defer sess_payload.deinit(alloc);
     {
@@ -301,9 +346,12 @@ test "QUIC streams: BCAST handshake then SESS session_open (wire framing)" {
     try quic.streamQueueWrite(cli_sess, sess_payload.items);
     try quic.streamDrainWrites(cli_sess, srv, 10_000);
 
-    const srv_sess = try acceptIncomingQuicStream(sc, srv, client_ep);
+    // Server accepts the SESS UNI stream (peer_in.go runAcceptLoop).
+    const srv_sess = try acceptIncomingQuicUniStream(sc, srv, client_ep);
     try waitQuicStreamBytes(srv_sess, srv, client_ep, sess_payload.items.len, 10_000);
     try std.testing.expectEqualSlices(u8, sess_payload.items, quic.streamReadSlice(srv_sess));
+
+    // Decode SESS session_open frame.
     const sess_copy = try alloc.dupe(u8, quic.streamReadSlice(srv_sess));
     defer alloc.free(sess_copy);
     var sess_fbs = std.io.fixedBufferStream(sess_copy);

--- a/src/transport/eth_ec_quic_peer.zig
+++ b/src/transport/eth_ec_quic_peer.zig
@@ -1,0 +1,161 @@
+//! Poll-driven `PeerConn` state machine for the ethp2p QUIC peer lifecycle.
+//!
+//! Models the lifecycle from `broadcast/peer.go`, `peer_ctrl.go`, `peer_in.go`
+//! in the Go reference without goroutines.  Callers drive progress by calling
+//! `poll` on the underlying `QuicEndpoint` then calling `drive()` on this struct.
+//!
+//! **Sketch only** — not wired to an Engine or channel table yet.  Demonstrates
+//! that the symmetric BCAST handshake and `runAcceptLoop` pattern are achievable
+//! in a single-threaded, poll-driven Zig context.
+
+const std = @import("std");
+const quic = @import("quic");
+const broadcast = @import("../wire/broadcast.zig");
+const bcast_stream = @import("../wire/bcast_stream.zig");
+const protocol = @import("../wire/protocol.zig");
+
+/// Lifecycle state of a `PeerConn`.
+pub const PeerConnState = enum {
+    /// Handshake not yet started.
+    idle,
+    /// Outbound BCAST UNI stream opened; waiting for the peer's inbound BCAST UNI stream.
+    handshaking,
+    /// Both BCAST streams are in place; active session.
+    active,
+    /// Terminal state — peer closed or error.
+    closed,
+};
+
+/// Inbound stream kind, matched by the single-byte selector (protocol.zig).
+pub const InboundStreamKind = enum { bcast, sess, chunk, unknown };
+
+/// A minimal peer connection that manages the BCAST control streams and
+/// dispatches incoming UNI streams by protocol type.
+///
+/// Matches `PeerConn` in `broadcast/peer.go`.
+pub const PeerConn = struct {
+    conn: *quic.QuicConnection,
+    ep: *quic.QuicEndpoint,
+    state: PeerConnState,
+
+    /// Our outbound BCAST UNI stream (`ctrlOut` in peer.go).
+    bcast_out: ?*quic.QuicStream,
+    /// The peer's inbound BCAST UNI stream (`ctrlIn` in peer.go).
+    bcast_in: ?*quic.QuicStream,
+
+    allocator: std.mem.Allocator,
+
+    pub fn init(
+        allocator: std.mem.Allocator,
+        conn: *quic.QuicConnection,
+        ep: *quic.QuicEndpoint,
+    ) PeerConn {
+        return .{
+            .conn = conn,
+            .ep = ep,
+            .state = .idle,
+            .bcast_out = null,
+            .bcast_in = null,
+            .allocator = allocator,
+        };
+    }
+
+    /// Start the handshake: open the outbound BCAST UNI stream and write
+    /// the handshake message.
+    ///
+    /// Matches `peer.go handshake()` writer goroutine:
+    ///   s, err := conn.OpenUniStream(ctx)
+    ///   protocol.WriteSelector(s, PROTOCOL_BCAST)
+    ///   WriteFrame(s, hsMsg)
+    ///
+    /// The caller must continue calling `drive()` to accept the peer's
+    /// inbound BCAST stream.
+    pub fn beginHandshake(
+        self: *PeerConn,
+        poll_peer: ?*quic.QuicEndpoint,
+        hs: broadcast.Handshake,
+    ) !void {
+        if (self.state != .idle) return error.InvalidState;
+
+        const out = try quic.streamMakeUni(self.conn, poll_peer);
+        self.bcast_out = out;
+
+        var buf = std.ArrayList(u8).empty;
+        defer buf.deinit(self.allocator);
+        try bcast_stream.writeBcastHandshakeOpen(buf.writer(self.allocator), self.allocator, hs);
+        try quic.streamQueueWrite(out, buf.items);
+
+        self.state = .handshaking;
+    }
+
+    /// Drive the peer connection forward (call after `quic.poll`).
+    ///
+    /// - In `handshaking` state: flush the outbound BCAST write and try to
+    ///   accept the peer's inbound BCAST UNI stream.
+    /// - In `active` state: process all pending inbound UNI streams.
+    ///
+    /// Returns `true` when a state transition occurred (caller may want to act).
+    pub fn drive(self: *PeerConn) bool {
+        switch (self.state) {
+            .idle, .closed => return false,
+            .handshaking => {
+                // Try to accept the peer's BCAST UNI stream.
+                if (self.bcast_in == null) {
+                    if (quic.tryAcceptIncomingUniStream(self.conn)) |st| {
+                        self.bcast_in = st;
+                        self.state = .active;
+                        return true;
+                    }
+                }
+                return false;
+            },
+            .active => {
+                var transitioned = false;
+                // Process incoming UNI streams (runAcceptLoop in peer_in.go).
+                while (quic.tryAcceptIncomingUniStream(self.conn)) |st| {
+                    self.dispatchInboundUniStream(st);
+                    transitioned = true;
+                }
+                return transitioned;
+            },
+        }
+    }
+
+    /// Dispatch an inbound UNI stream by reading its single-byte selector.
+    ///
+    /// Matches `runAcceptLoop` in `peer_in.go`:
+    ///   prot, err := protocol.ReadSelector(s)
+    ///   switch prot {
+    ///   case SESS: go runInboundSession(s)
+    ///   case CHUNK: go processChunk(s)
+    ///   }
+    ///
+    /// In this sketch the dispatch is a no-op after classification.
+    /// A full implementation would hand `st` off to the session or chunk handler.
+    fn dispatchInboundUniStream(self: *PeerConn, st: *quic.QuicStream) void {
+        _ = self;
+        const raw = quic.streamReadSlice(st);
+        if (raw.len == 0) return;
+
+        const sel: protocol.Protocol = @enumFromInt(raw[0]);
+        const kind: InboundStreamKind = switch (sel) {
+            .bcast => .bcast,
+            .sess => .sess,
+            .chunk => .chunk,
+            else => .unknown,
+        };
+        _ = kind;
+        // TODO: hand off `st` to the appropriate handler (session table / chunk semaphore).
+    }
+
+    /// Graceful shutdown: close the outbound BCAST stream and mark closed.
+    pub fn close(self: *PeerConn) void {
+        if (self.bcast_out) |s| quic.streamCancelWrite(s);
+        self.bcast_out = null;
+        self.bcast_in = null;
+        self.state = .closed;
+    }
+};
+
+/// Convenience re-export of the type accepted by `PeerConn.beginHandshake`.
+pub const HandshakeArgs = broadcast.Handshake;

--- a/src/transport/lsquic_quic_shim.zig
+++ b/src/transport/lsquic_quic_shim.zig
@@ -7,6 +7,7 @@ const posix = std.posix;
 const lsquic = @cImport({
     @cInclude("lsquic.h");
     @cInclude("lsquic_types.h");
+    @cInclude("lsquic_ethp2p_ext.h");
 });
 
 const ossl = @cImport({
@@ -221,6 +222,11 @@ pub const QuicConnection = struct {
         read_buf: std.ArrayListUnmanaged(u8),
         write_buf: std.ArrayListUnmanaged(u8),
         write_off: usize,
+        /// Set by `on_reset` when the peer resets this stream.
+        /// `how`: 0 = read side reset (RESET_STREAM received),
+        ///        1 = write side reset (STOP_SENDING received),
+        ///        2 = both.
+        reset_how: ?i32 = null,
 
         pub fn deinit(self: *Stream) void {
             const a = self.conn.ep.allocator.*;
@@ -232,10 +238,15 @@ pub const QuicConnection = struct {
     raw: *lsquic.lsquic_conn_t,
     ep: *QuicEndpoint,
     hsk_ok: bool,
+    /// Incoming peer-initiated bidirectional streams waiting to be accepted.
     incoming_streams: std.ArrayListUnmanaged(*Stream),
+    /// Incoming peer-initiated unidirectional streams waiting to be accepted.
+    incoming_uni_streams: std.ArrayListUnmanaged(*Stream),
     streams_owned: std.ArrayListUnmanaged(*Stream),
-    /// Client/server: `streamMake` leaves a `Stream` here until `on_new_stream` binds `raw`.
+    /// `streamMake` leaves a bidi `Stream` here until `on_new_stream` binds `raw`.
     stream_outgoing_ready: ?*Stream,
+    /// `streamMakeUni` leaves a uni `Stream` here until `on_new_stream` binds `raw`.
+    stream_outgoing_uni_ready: ?*Stream,
 
     fn freeAllStreams(self: *QuicConnection) void {
         const a = self.ep.allocator.*;
@@ -244,7 +255,13 @@ pub const QuicConnection = struct {
             a.destroy(p);
             self.stream_outgoing_ready = null;
         }
+        if (self.stream_outgoing_uni_ready) |p| {
+            p.deinit();
+            a.destroy(p);
+            self.stream_outgoing_uni_ready = null;
+        }
         self.incoming_streams.clearAndFree(a);
+        self.incoming_uni_streams.clearAndFree(a);
         for (self.streams_owned.items) |st| {
             st.deinit();
             a.destroy(st);
@@ -265,6 +282,14 @@ pub const QuicConnection = struct {
         while (i < self.incoming_streams.items.len) {
             if (self.incoming_streams.items[i] == st) {
                 _ = self.incoming_streams.swapRemove(i);
+                break;
+            }
+            i += 1;
+        }
+        i = 0;
+        while (i < self.incoming_uni_streams.items.len) {
+            if (self.incoming_uni_streams.items[i] == st) {
+                _ = self.incoming_uni_streams.swapRemove(i);
                 break;
             }
             i += 1;
@@ -416,8 +441,10 @@ fn onNewConn(stream_if_ctx: ?*anyopaque, c: ?*lsquic.lsquic_conn_t) callconv(.c)
         .ep = ep,
         .hsk_ok = false,
         .incoming_streams = .{},
+        .incoming_uni_streams = .{},
         .streams_owned = .{},
         .stream_outgoing_ready = null,
+        .stream_outgoing_uni_ready = null,
     };
     lsquic.lsquic_conn_set_ctx(c, @ptrCast(qc));
     if (ep.is_server) {
@@ -449,6 +476,50 @@ fn onNewStream(stream_if_ctx: ?*anyopaque, s: ?*lsquic.lsquic_stream_t) callconv
     const raw_conn = lsquic.lsquic_stream_conn(s.?);
     const qc: *QuicConnection = @ptrCast(@alignCast(lsquic.lsquic_conn_get_ctx(raw_conn) orelse return null));
 
+    // QUIC stream ID encoding (RFC 9000 §2.1):
+    //   bit 0: 0 = initiator is client, 1 = initiator is server
+    //   bit 1: 0 = bidirectional, 1 = unidirectional
+    const sid = lsquic.lsquic_stream_id(s.?);
+    const is_uni = (sid & 0x2) != 0;
+
+    if (is_uni) {
+        // Unidirectional stream: check if it is our outgoing stream.
+        if (qc.stream_outgoing_uni_ready) |tgt| {
+            tgt.raw = s.?;
+            lsquic.lsquic_stream_set_ctx(s.?, @ptrCast(tgt));
+            qc.stream_outgoing_uni_ready = null;
+            qc.streams_owned.append(alloc, tgt) catch {
+                _ = lsquic.lsquic_stream_close(s.?);
+                return null;
+            };
+            // Outgoing UNI streams are write-only; do not request reads.
+            _ = lsquic.lsquic_stream_wantwrite(s.?, 0);
+            return @ptrCast(tgt);
+        }
+        // Incoming UNI stream from peer.
+        const inc = alloc.create(QuicStream) catch return null;
+        inc.* = .{
+            .raw = s.?,
+            .conn = qc,
+            .read_buf = .{},
+            .write_buf = .{},
+            .write_off = 0,
+        };
+        lsquic.lsquic_stream_set_ctx(s.?, @ptrCast(inc));
+        qc.streams_owned.append(alloc, inc) catch {
+            alloc.destroy(inc);
+            return null;
+        };
+        qc.incoming_uni_streams.append(alloc, inc) catch {
+            _ = qc.streams_owned.pop();
+            alloc.destroy(inc);
+            return null;
+        };
+        _ = lsquic.lsquic_stream_wantread(s.?, 1);
+        return @ptrCast(inc);
+    }
+
+    // Bidirectional stream: check if it is our outgoing stream.
     if (qc.stream_outgoing_ready) |tgt| {
         tgt.raw = s.?;
         lsquic.lsquic_stream_set_ctx(s.?, @ptrCast(tgt));
@@ -462,6 +533,7 @@ fn onNewStream(stream_if_ctx: ?*anyopaque, s: ?*lsquic.lsquic_stream_t) callconv
         return @ptrCast(tgt);
     }
 
+    // Incoming bidirectional stream from peer.
     const inc = alloc.create(QuicStream) catch return null;
     inc.* = .{
         .raw = s.?,
@@ -538,6 +610,14 @@ fn onStreamClose(s: ?*lsquic.lsquic_stream_t, h: ?*lsquic.lsquic_stream_ctx_t) c
     st.conn.ep.allocator.destroy(st);
 }
 
+fn onStreamReset(s: ?*lsquic.lsquic_stream_t, h: ?*lsquic.lsquic_stream_ctx_t, how: c_int) callconv(.c) void {
+    _ = s;
+    if (h == null) return;
+    const st: *QuicStream = @ptrCast(@alignCast(h.?));
+    // Record which direction was reset: 0=read, 1=write, 2=both.
+    st.reset_how = how;
+}
+
 fn onHskDone(c: ?*lsquic.lsquic_conn_t, status: lsquic.enum_lsquic_hsk_status) callconv(.c) void {
     if (status != lsquic.LSQ_HSK_OK and status != lsquic.LSQ_HSK_RESUMED_OK) return;
     const qc: *QuicConnection = @ptrCast(@alignCast(lsquic.lsquic_conn_get_ctx(c.?)));
@@ -557,7 +637,7 @@ const stream_if: lsquic.lsquic_stream_if = .{
     .on_hsk_done = onHskDone,
     .on_new_token = null,
     .on_sess_resume_info = null,
-    .on_reset = null,
+    .on_reset = onStreamReset,
     .on_conncloseframe_received = null,
 };
 
@@ -781,6 +861,13 @@ pub fn tryAcceptIncomingStream(conn: *QuicConnection) ?*QuicStream {
     return conn.incoming_streams.swapRemove(0);
 }
 
+/// Pop the next peer-initiated unidirectional stream, if any.
+/// These are the streams used by the ethp2p reference for BCAST, SESS, and CHUNK.
+pub fn tryAcceptIncomingUniStream(conn: *QuicConnection) ?*QuicStream {
+    if (conn.incoming_uni_streams.items.len == 0) return null;
+    return conn.incoming_uni_streams.swapRemove(0);
+}
+
 /// Open a locally initiated bidirectional stream (calls `lsquic_conn_make_stream`). Requires a
 /// completed handshake. Drives `poll` on this connection until the stream exists or a bound is hit.
 /// When `poll_peer` is non-null, it is polled each iteration as well (needed on loopback so both
@@ -812,6 +899,58 @@ pub fn streamMake(conn: *QuicConnection, poll_peer: ?*QuicEndpoint) !*QuicStream
         return error.StreamCreateFailed;
     }
     return qs;
+}
+
+/// Open a locally initiated unidirectional stream (calls `lsquic_conn_make_uni_stream`). Requires
+/// a completed handshake. The ethp2p reference uses UNI streams for BCAST control, SESS session
+/// open/routing, and CHUNK data (`peer.go`, `peer_ctrl.go`, `peer_in.go`).
+///
+/// `on_new_stream` fires synchronously inside `lsquic_conn_make_uni_stream`; the polling loop is a
+/// safety fallback in case lsquic defers the callback in some edge case.
+pub fn streamMakeUni(conn: *QuicConnection, poll_peer: ?*QuicEndpoint) !*QuicStream {
+    if (conn.stream_outgoing_uni_ready != null) return error.StreamSpawnPending;
+    if (!connHandshakeReady(conn)) return error.HandshakeNotComplete;
+    const alloc = conn.ep.allocator.*;
+    const qs = try alloc.create(QuicStream);
+    qs.* = .{
+        .raw = null,
+        .conn = conn,
+        .read_buf = .{},
+        .write_buf = .{},
+        .write_off = 0,
+    };
+    conn.stream_outgoing_uni_ready = qs;
+    _ = lsquic.lsquic_conn_make_uni_stream(conn.raw);
+    // on_new_stream fires synchronously; qs.raw should be set already.
+    if (qs.raw == null) {
+        conn.ep.processEngine();
+        var i: u32 = 0;
+        while (qs.raw == null and i < 10_000) : (i += 1) {
+            try poll(conn.ep, 0);
+            if (poll_peer) |p| try poll(p, 0);
+        }
+    }
+    if (qs.raw == null) {
+        if (conn.stream_outgoing_uni_ready == qs) conn.stream_outgoing_uni_ready = null;
+        qs.deinit();
+        alloc.destroy(qs);
+        return error.StreamCreateFailed;
+    }
+    return qs;
+}
+
+/// Cancel the write side of a stream, sending a QUIC RESET_STREAM frame to the peer.
+/// This is used by the ethp2p reference when a session is reconstructed (`sessCodeReconstructed`).
+/// Note: the lsquic 4.3 public API does not expose an application error code for this frame;
+/// `lsquic_stream_shutdown(SHUT_WR)` sends a FIN rather than RESET_STREAM. Use `lsquic_stream_close`
+/// as the closest available equivalent.
+pub fn streamCancelWrite(st: *QuicStream) void {
+    if (st.raw) |s| _ = lsquic.lsquic_stream_close(s);
+}
+
+/// Cancel the read side of a stream, sending a QUIC STOP_SENDING frame to the peer.
+pub fn streamCancelRead(st: *QuicStream) void {
+    if (st.raw) |s| _ = lsquic.lsquic_stream_shutdown(s, 0); // SHUT_RD
 }
 
 pub fn streamQueueWrite(st: *QuicStream, data: []const u8) !void {

--- a/vendor/lsquic_zig/build.zig
+++ b/vendor/lsquic_zig/build.zig
@@ -112,14 +112,31 @@ pub fn build(b: *std.Build) void {
     lib.installHeader(lshpack_dep.path("deps/xxhash/xxhash.h"), "xxhash.h");
     lib.root_module.addCMacro("XXH_HEADER_NAME", "\"xxhash.h\"");
 
+    // Patch lsquic_full_conn_ietf.c to expose create_uni_stream_out as a
+    // non-static symbol and append a public lsquic_conn_make_uni_stream()
+    // wrapper.  The patched copy lives in the Zig output cache; the
+    // original upstream file is untouched.
+    const patch_run = b.addSystemCommand(&.{"sh"});
+    patch_run.addFileArg(b.path("patch_uni.sh"));
+    patch_run.addFileArg(upstream.path("src/liblsquic/lsquic_full_conn_ietf.c"));
+    const patched_ietf = patch_run.addOutputFileArg("lsquic_full_conn_ietf.c");
+
     lib.addCSourceFiles(.{
         .root = upstream.path("src/liblsquic"),
-        .files = lsquic_files,
+        .files = lsquic_files_no_ietf,
         .flags = c_flags.items,
     });
+    // Add the patched IETF full-connection source with the same include paths
+    // as the rest of lsquic (both the public include/ and the internal src/).
+    lib.addCSourceFile(.{ .file = patched_ietf, .flags = c_flags.items });
+    lib.addIncludePath(upstream.path("src/liblsquic"));
+
     lib.addCSourceFile(.{ .file = lsqpack_dep.path("lsqpack.c"), .flags = c_flags.items });
     lib.addCSourceFile(.{ .file = lshpack_dep.path("lshpack.c"), .flags = c_flags.items });
     lib.addCSourceFile(.{ .file = lshpack_dep.path("deps/xxhash/xxhash.c"), .flags = c_flags.items });
+
+    // Install the zig-ethp2p extension header alongside lsquic's own headers.
+    lib.installHeader(b.path("lsquic_ethp2p_ext.h"), "lsquic_ethp2p_ext.h");
 
     b.installArtifact(lib);
 
@@ -127,7 +144,9 @@ pub fn build(b: *std.Build) void {
     _ = test_step;
 }
 
-const lsquic_files: []const []const u8 = &.{
+// lsquic_full_conn_ietf.c is excluded here; a patched copy is compiled
+// separately (see patch_run above) to expose create_uni_stream_out.
+const lsquic_files_no_ietf: []const []const u8 = &.{
     "ls-sfparser.c",
     "lsquic_adaptive_cc.c",
     "lsquic_alarmset.c",
@@ -155,7 +174,6 @@ const lsquic_files: []const []const u8 = &.{
     "lsquic_frame_reader.c",
     "lsquic_frame_writer.c",
     "lsquic_full_conn.c",
-    "lsquic_full_conn_ietf.c",
     "lsquic_global.c",
     "lsquic_handshake.c",
     "lsquic_hash.c",

--- a/vendor/lsquic_zig/lsquic_ethp2p_ext.h
+++ b/vendor/lsquic_zig/lsquic_ethp2p_ext.h
@@ -1,0 +1,36 @@
+/* lsquic_ethp2p_ext.h -- zig-ethp2p extensions to the lsquic public API.
+ *
+ * These declarations cover capabilities that are internal to lsquic but
+ * needed for non-HTTP unidirectional QUIC stream support (BCAST/SESS/CHUNK
+ * protocols used by github.com/ethp2p/ethp2p).
+ */
+#ifndef LSQUIC_ETHP2P_EXT_H
+#define LSQUIC_ETHP2P_EXT_H
+
+#include "lsquic.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * Open a new outbound unidirectional stream on `conn`.
+ *
+ * Analogous to lsquic_conn_make_stream() but uses the QUIC unidirectional
+ * stream namespace (client-initiated IDs 2, 6, 10 … or server-initiated
+ * IDs 3, 7, 11 …, depending on which side this connection represents).
+ *
+ * The on_new_stream callback fires synchronously before this function
+ * returns; the resulting stream context is write-only (the read side always
+ * yields EOF to the opener).
+ *
+ * Returns 0 on success, -1 on allocation failure.
+ * Must only be called after the QUIC handshake is complete.
+ */
+int lsquic_conn_make_uni_stream(lsquic_conn_t *conn);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* LSQUIC_ETHP2P_EXT_H */

--- a/vendor/lsquic_zig/patch_uni.sh
+++ b/vendor/lsquic_zig/patch_uni.sh
@@ -1,0 +1,30 @@
+#!/bin/sh
+# patch_uni.sh <input_c> <output_c>
+#
+# Patches lsquic_full_conn_ietf.c to:
+#   1. Remove 'static' from create_uni_stream_out so it can be called externally.
+#   2. Append a public lsquic_conn_make_uni_stream() wrapper at the end of the file.
+#
+# awk replaces the 'static int' line that immediately precedes create_uni_stream_out,
+# leaving all other 'static int' functions unchanged.
+awk '
+/^static int$/ { pending = 1; buf = $0; next }
+pending && /^create_uni_stream_out/ { print "int"; pending = 0 }
+pending { print buf; pending = 0 }
+{ print }
+' "$1" > "$2"
+
+cat >> "$2" <<'EOF'
+
+/* zig-ethp2p extension: public wrapper for non-HTTP unidirectional stream creation.
+ * Exposes create_uni_stream_out (now non-static above) so callers outside this
+ * translation unit can open outbound UNI streams without HTTP/3. */
+int
+lsquic_conn_make_uni_stream (lsquic_conn_t *lconn)
+{
+    struct ietf_full_conn *const conn = (struct ietf_full_conn *) lconn;
+    return create_uni_stream_out(conn, 0,
+                                 conn->ifc_enpub->enp_stream_if,
+                                 conn->ifc_enpub->enp_stream_if_ctx);
+}
+EOF


### PR DESCRIPTION
## Summary

Fixes #28 — switches the BCAST/SESS/CHUNK transport from **bidirectional** to **unidirectional** QUIC streams, matching `peer.go` `OpenUniStream`/`AcceptUniStream` throughout the ethp2p Go reference.

**Wire interop problem solved:** PR #35 (issue #27) used bidi streams (QUIC IDs 0, 4, 8…). The Go reference uses uni streams for all application protocols. If zig-ethp2p sent stream ID 0 (bidi), Go's `AcceptUniStream` would ignore it entirely.

## Changes

### Vendor patch (`vendor/lsquic_zig/`)

lsquic 4.3 has no public API for outgoing UNI streams. Solution:

- `patch_uni.sh` — shell script that removes `static` from `create_uni_stream_out` in a build-time copy of `lsquic_full_conn_ietf.c` and appends a public `lsquic_conn_make_uni_stream()` wrapper. The upstream source file is untouched.
- `lsquic_ethp2p_ext.h` — public declaration of `lsquic_conn_make_uni_stream`
- `build.zig` — runs the patch as a `b.addSystemCommand` build step; compiles the patched file with the same flags as the rest of lsquic

### Shim (`src/transport/lsquic_quic_shim.zig`)

- Detect stream type via `lsquic_stream_id() & 0x2` (RFC 9000 §2.1: bit 1 = unidirectional)
- `incoming_uni_streams` queue + `tryAcceptIncomingUniStream`
- `stream_outgoing_uni_ready` slot + `streamMakeUni`
- `on_reset` callback records `QuicStream.reset_how`
- `streamCancelWrite` / `streamCancelRead` teardown helpers

### Integration test (`src/transport/eth_ec_quic_enabled.zig`)

Replaces the bidi BCAST/SESS test with the correct **symmetric UNI handshake**: both sides open their outbound BCAST UNI stream before either reads, matching `peer.go`'s concurrent goroutine design. Test also covers SESS UNI stream via `peer_ctrl.go` path.

### PeerConn sketch (`src/transport/eth_ec_quic_peer.zig`) — new file

Poll-driven `PeerConn` state machine: `idle → handshaking → active → closed`. Covers `beginHandshake` (open outbound BCAST UNI + write handshake), `drive` (flush writes, accept inbound BCAST → go active, dispatch incoming UNI streams by selector byte), and `close`. Not yet wired to `Engine`/channel tables.

### Docs

- `README.md` — new "UNI stream alignment" row in the implementation table; updated QUIC transport "Still open" and "Pending work" sections
- `UPSTREAM.md` — documents UNI stream alignment, vendor patch mechanic, libp2p boundary

## Test plan

- [x] `zig fmt --check .`
- [x] `zig build test --summary all` (74/74 tests pass)
- [x] `zig build test-quic -Denable-quic --summary all` (17/17 tests pass)
- [x] `zig build simtest --summary all` (74/74 tests pass)

## Out of scope

Per the issue "Note": production deployments may layer libp2p (Noise, multistream-select, Yamux, identify) on top of the QUIC transport. That is handled by zeam's rust-libp2p layer and is not part of this PR.