### PR TITLE
plug memory leaks on error paths (adversarial review)

### DIFF
--- a/src/broadcast/channel_rs.zig
+++ b/src/broadcast/channel_rs.zig
@@ -84,17 +84,18 @@ pub const ChannelRs = struct {
 
         const n = self.members.items.len;
         const member_ids = try self.allocator.alloc([]u8, n);
+        var populated: usize = 0;
         errdefer {
-            for (member_ids) |m| self.allocator.free(m);
+            for (member_ids[0..populated]) |m| self.allocator.free(m);
             self.allocator.free(member_ids);
         }
         const stats = try self.allocator.alloc(broadcast_types.PeerSessionStats, n);
         errdefer self.allocator.free(stats);
 
-        for (0..n) |i| {
-            member_ids[i] = try self.allocator.dupe(u8, self.members.items[i]);
-            stats[i] = .{ .peer_id = member_ids[i] };
-            try strat.?.attachPeer(member_ids[i], &stats[i]);
+        while (populated < n) : (populated += 1) {
+            member_ids[populated] = try self.allocator.dupe(u8, self.members.items[populated]);
+            stats[populated] = .{ .peer_id = member_ids[populated] };
+            try strat.?.attachPeer(member_ids[populated], &stats[populated]);
         }
 
         const sess = try self.allocator.create(SessionRs);
@@ -126,17 +127,18 @@ pub const ChannelRs = struct {
 
         const n = self.members.items.len;
         const member_ids = try self.allocator.alloc([]u8, n);
+        var populated: usize = 0;
         errdefer {
-            for (member_ids) |m| self.allocator.free(m);
+            for (member_ids[0..populated]) |m| self.allocator.free(m);
             self.allocator.free(member_ids);
         }
         const stats = try self.allocator.alloc(broadcast_types.PeerSessionStats, n);
         errdefer self.allocator.free(stats);
 
-        for (0..n) |i| {
-            member_ids[i] = try self.allocator.dupe(u8, self.members.items[i]);
-            stats[i] = .{ .peer_id = member_ids[i] };
-            try strat.attachPeer(member_ids[i], &stats[i]);
+        while (populated < n) : (populated += 1) {
+            member_ids[populated] = try self.allocator.dupe(u8, self.members.items[populated]);
+            stats[populated] = .{ .peer_id = member_ids[populated] };
+            try strat.attachPeer(member_ids[populated], &stats[populated]);
         }
 
         const sess = try self.allocator.create(SessionRs);

--- a/src/discovery/discv5/protocol.zig
+++ b/src/discovery/discv5/protocol.zig
@@ -108,6 +108,19 @@ fn encodeReqId(allocator: std.mem.Allocator, id: u64) EncodeError![]u8 {
     return rlpEncodeUint64(allocator, id);
 }
 
+/// Append `buf` to `items`, freeing `buf` on allocation failure so the caller's
+/// nested-try expression cannot leak the freshly encoded slice.
+fn appendOwned(
+    items: *std.ArrayListUnmanaged([]u8),
+    allocator: std.mem.Allocator,
+    buf: []u8,
+) std.mem.Allocator.Error!void {
+    items.append(allocator, buf) catch |err| {
+        allocator.free(buf);
+        return err;
+    };
+}
+
 /// Decode a request-id from an RLP item (variable-length integer).
 fn decodeReqId(item: []const u8) DecodeError!u64 {
     const bytes = try rlpStringValue(item);
@@ -127,8 +140,8 @@ pub fn encodePing(allocator: std.mem.Allocator, msg: Ping) EncodeError![]u8 {
         items.deinit(allocator);
     }
 
-    try items.append(allocator, try encodeReqId(allocator, msg.request_id));
-    try items.append(allocator, try rlpEncodeUint64(allocator, msg.enr_seq));
+    try appendOwned(&items, allocator, try encodeReqId(allocator, msg.request_id));
+    try appendOwned(&items, allocator, try rlpEncodeUint64(allocator, msg.enr_seq));
 
     const body = try rlpEncodeList(allocator, @ptrCast(items.items));
     defer allocator.free(body);
@@ -166,10 +179,10 @@ pub fn encodePong(allocator: std.mem.Allocator, msg: Pong) EncodeError![]u8 {
         items.deinit(allocator);
     }
 
-    try items.append(allocator, try encodeReqId(allocator, msg.request_id));
-    try items.append(allocator, try rlpEncodeUint64(allocator, msg.enr_seq));
-    try items.append(allocator, try rlpEncodeString(allocator, msg.recipient_ip[0..msg.ip_len]));
-    try items.append(allocator, try rlpEncodeUint64(allocator, msg.recipient_port));
+    try appendOwned(&items, allocator, try encodeReqId(allocator, msg.request_id));
+    try appendOwned(&items, allocator, try rlpEncodeUint64(allocator, msg.enr_seq));
+    try appendOwned(&items, allocator, try rlpEncodeString(allocator, msg.recipient_ip[0..msg.ip_len]));
+    try appendOwned(&items, allocator, try rlpEncodeUint64(allocator, msg.recipient_port));
 
     const body = try rlpEncodeList(allocator, @ptrCast(items.items));
     defer allocator.free(body);
@@ -219,7 +232,7 @@ pub fn encodeFindNode(allocator: std.mem.Allocator, msg: FindNode) EncodeError![
         items.deinit(allocator);
     }
 
-    try items.append(allocator, try encodeReqId(allocator, msg.request_id));
+    try appendOwned(&items, allocator, try encodeReqId(allocator, msg.request_id));
 
     // distances is a list of u8 values.
     var dist_items = std.ArrayListUnmanaged([]u8){};
@@ -228,9 +241,9 @@ pub fn encodeFindNode(allocator: std.mem.Allocator, msg: FindNode) EncodeError![
         dist_items.deinit(allocator);
     }
     for (msg.distances) |d| {
-        try dist_items.append(allocator, try rlpEncodeUint64(allocator, d));
+        try appendOwned(&dist_items, allocator, try rlpEncodeUint64(allocator, d));
     }
-    try items.append(allocator, try rlpEncodeList(allocator, @ptrCast(dist_items.items)));
+    try appendOwned(&items, allocator, try rlpEncodeList(allocator, @ptrCast(dist_items.items)));
 
     const body = try rlpEncodeList(allocator, @ptrCast(items.items));
     defer allocator.free(body);
@@ -252,11 +265,12 @@ pub fn decodeFindNode(allocator: std.mem.Allocator, data: []const u8) (DecodeErr
     const dists_payload = try enr_mod.rlpListPayload(dists_item.item);
 
     var dist_list = std.ArrayListUnmanaged(u8){};
+    errdefer dist_list.deinit(allocator);
     var dr = dists_payload;
     while (dr.len > 0) {
         const d_item = try rlpDecode(dr);
         dr = d_item.rest;
-        dist_list.append(allocator, @intCast(try decodeReqId(d_item.item))) catch return error.OutOfMemory;
+        try dist_list.append(allocator, @intCast(try decodeReqId(d_item.item)));
     }
 
     return .{
@@ -280,8 +294,8 @@ pub fn encodeNodes(allocator: std.mem.Allocator, msg: Nodes) EncodeError![]u8 {
         items.deinit(allocator);
     }
 
-    try items.append(allocator, try encodeReqId(allocator, msg.request_id));
-    try items.append(allocator, try rlpEncodeUint64(allocator, msg.total));
+    try appendOwned(&items, allocator, try encodeReqId(allocator, msg.request_id));
+    try appendOwned(&items, allocator, try rlpEncodeUint64(allocator, msg.total));
 
     var enr_items = std.ArrayListUnmanaged([]u8){};
     defer {
@@ -289,9 +303,9 @@ pub fn encodeNodes(allocator: std.mem.Allocator, msg: Nodes) EncodeError![]u8 {
         enr_items.deinit(allocator);
     }
     for (msg.enrs) |enr_bytes| {
-        try enr_items.append(allocator, try allocator.dupe(u8, enr_bytes));
+        try appendOwned(&enr_items, allocator, try allocator.dupe(u8, enr_bytes));
     }
-    try items.append(allocator, try rlpEncodeList(allocator, @ptrCast(enr_items.items)));
+    try appendOwned(&items, allocator, try rlpEncodeList(allocator, @ptrCast(enr_items.items)));
 
     const body = try rlpEncodeList(allocator, @ptrCast(items.items));
     defer allocator.free(body);
@@ -315,14 +329,18 @@ pub fn decodeNodes(allocator: std.mem.Allocator, data: []const u8) (DecodeError 
     const enrs_payload = try enr_mod.rlpListPayload(enrs_item.item);
 
     var enr_list = std.ArrayListUnmanaged([]const u8){};
+    errdefer {
+        for (enr_list.items) |e| allocator.free(e);
+        enr_list.deinit(allocator);
+    }
     var er = enrs_payload;
     while (er.len > 0) {
         const e = try rlpDecode(er);
         er = e.rest;
         const copy = try allocator.dupe(u8, e.item);
-        enr_list.append(allocator, copy) catch {
+        enr_list.append(allocator, copy) catch |err| {
             allocator.free(copy);
-            return error.OutOfMemory;
+            return err;
         };
     }
 
@@ -349,9 +367,9 @@ pub fn encodeTalkReq(allocator: std.mem.Allocator, msg: TalkReq) EncodeError![]u
         items.deinit(allocator);
     }
 
-    try items.append(allocator, try encodeReqId(allocator, msg.request_id));
-    try items.append(allocator, try rlpEncodeString(allocator, msg.protocol));
-    try items.append(allocator, try rlpEncodeString(allocator, msg.payload));
+    try appendOwned(&items, allocator, try encodeReqId(allocator, msg.request_id));
+    try appendOwned(&items, allocator, try rlpEncodeString(allocator, msg.protocol));
+    try appendOwned(&items, allocator, try rlpEncodeString(allocator, msg.payload));
 
     const body = try rlpEncodeList(allocator, @ptrCast(items.items));
     defer allocator.free(body);
@@ -396,8 +414,8 @@ pub fn encodeTalkRes(allocator: std.mem.Allocator, msg: TalkRes) EncodeError![]u
         items.deinit(allocator);
     }
 
-    try items.append(allocator, try encodeReqId(allocator, msg.request_id));
-    try items.append(allocator, try rlpEncodeString(allocator, msg.payload));
+    try appendOwned(&items, allocator, try encodeReqId(allocator, msg.request_id));
+    try appendOwned(&items, allocator, try rlpEncodeString(allocator, msg.payload));
 
     const body = try rlpEncodeList(allocator, @ptrCast(items.items));
     defer allocator.free(body);

--- a/src/discovery/enr/enr.zig
+++ b/src/discovery/enr/enr.zig
@@ -318,6 +318,20 @@ pub fn rlpEncodeList(allocator: std.mem.Allocator, items: []const []const u8) st
 // ENR encode + sign  (EIP-778 §4, v4 identity scheme)
 // ---------------------------------------------------------------------------
 
+/// Append `buf` (already owned by the caller) to `items`, freeing `buf` on
+/// allocation failure so the outer `try append(alloc, try alloc...())` pattern
+/// does not leak the freshly encoded slice if the list grow fails.
+fn appendOwnedItem(
+    items: *std.ArrayListUnmanaged([]u8),
+    allocator: std.mem.Allocator,
+    buf: []u8,
+) std.mem.Allocator.Error!void {
+    items.append(allocator, buf) catch |err| {
+        allocator.free(buf);
+        return err;
+    };
+}
+
 /// Builder for assembling a signed ENR.
 ///
 /// Pairs must be added in lexicographic key order (the caller is responsible
@@ -361,10 +375,10 @@ pub const EnrBuilder = struct {
             items.deinit(self.allocator);
         }
 
-        try items.append(self.allocator, try rlpEncodeUint64(self.allocator, self.seq));
+        try appendOwnedItem(&items, self.allocator, try rlpEncodeUint64(self.allocator, self.seq));
         for (self.pairs.items) |kv| {
-            try items.append(self.allocator, try rlpEncodeString(self.allocator, kv.key));
-            try items.append(self.allocator, try self.allocator.dupe(u8, kv.value_raw));
+            try appendOwnedItem(&items, self.allocator, try rlpEncodeString(self.allocator, kv.key));
+            try appendOwnedItem(&items, self.allocator, try self.allocator.dupe(u8, kv.value_raw));
         }
         return rlpEncodeList(self.allocator, @ptrCast(items.items));
     }
@@ -388,11 +402,11 @@ pub const EnrBuilder = struct {
             items.deinit(self.allocator);
         }
 
-        try items.append(self.allocator, try rlpEncodeString(self.allocator, &sig));
-        try items.append(self.allocator, try rlpEncodeUint64(self.allocator, self.seq));
+        try appendOwnedItem(&items, self.allocator, try rlpEncodeString(self.allocator, &sig));
+        try appendOwnedItem(&items, self.allocator, try rlpEncodeUint64(self.allocator, self.seq));
         for (self.pairs.items) |kv| {
-            try items.append(self.allocator, try rlpEncodeString(self.allocator, kv.key));
-            try items.append(self.allocator, try self.allocator.dupe(u8, kv.value_raw));
+            try appendOwnedItem(&items, self.allocator, try rlpEncodeString(self.allocator, kv.key));
+            try appendOwnedItem(&items, self.allocator, try self.allocator.dupe(u8, kv.value_raw));
         }
 
         const record = try rlpEncodeList(self.allocator, @ptrCast(items.items));

--- a/src/sim/gossipsub_rpc_pb.zig
+++ b/src/sim/gossipsub_rpc_pb.zig
@@ -177,7 +177,11 @@ pub fn decodeIHaveOwned(allocator: Allocator, buf: []const u8) (DecodeError || A
                 if (topic != null) return error.BadTag;
                 topic = try allocator.dupe(u8, tl.payload);
             },
-            2 => try ids.append(allocator, try allocator.dupe(u8, tl.payload)),
+            2 => {
+                const copy = try allocator.dupe(u8, tl.payload);
+                errdefer allocator.free(copy);
+                try ids.append(allocator, copy);
+            },
             else => return error.BadTag,
         }
     }
@@ -199,7 +203,9 @@ pub fn decodeIWantOwned(allocator: Allocator, buf: []const u8) (DecodeError || A
     while (offset < buf.len) {
         const tl = try decodeTagLen(buf, &offset);
         if (tl.field != 1) return error.BadTag;
-        try ids.append(allocator, try allocator.dupe(u8, tl.payload));
+        const copy = try allocator.dupe(u8, tl.payload);
+        errdefer allocator.free(copy);
+        try ids.append(allocator, copy);
     }
 
     return .{ .message_ids = try ids.toOwnedSlice(allocator) };
@@ -509,7 +515,9 @@ pub fn decodeControlPruneOwned(allocator: Allocator, buf: []const u8) (DecodeErr
             2 => {
                 if (wire != 2) return error.BadWireType;
                 const pl = try decodeLengthDelimited(buf, &offset);
-                try peer_list.append(allocator, try decodePeerInfoOwned(allocator, pl));
+                var decoded = try decodePeerInfoOwned(allocator, pl);
+                errdefer decoded.deinit(allocator);
+                try peer_list.append(allocator, decoded);
             },
             3 => {
                 if (wire != 0) return error.BadWireType;
@@ -767,12 +775,16 @@ pub fn decodeRpcOwned(allocator: Allocator, buf: []const u8) (DecodeError || All
             1 => {
                 if (wire != 2) return error.BadWireType;
                 const pl = try decodeLengthDelimited(buf, &offset);
-                try subs.append(allocator, try decodeSubOptsOwned(allocator, pl));
+                var decoded = try decodeSubOptsOwned(allocator, pl);
+                errdefer decoded.deinit(allocator);
+                try subs.append(allocator, decoded);
             },
             2 => {
                 if (wire != 2) return error.BadWireType;
                 const pl = try decodeLengthDelimited(buf, &offset);
-                try pubs.append(allocator, try decodeGossipMessageOwned(allocator, pl));
+                var decoded = try decodeGossipMessageOwned(allocator, pl);
+                errdefer decoded.deinit(allocator);
+                try pubs.append(allocator, decoded);
             },
             3 => {
                 if (wire != 2) return error.BadWireType;

--- a/src/transport/zquic_quic_shim.zig
+++ b/src/transport/zquic_quic_shim.zig
@@ -575,6 +575,7 @@ pub fn streamMake(conn: *QuicConnection, poll_peer: ?*QuicEndpoint) !*QuicStream
         break :blk io.rawAllocateNextLocalBidiStream(cs);
     };
     const qs = try alloc.create(QuicStream);
+    errdefer alloc.destroy(qs);
     qs.* = .{
         .conn = conn,
         .stream_id = sid,
@@ -583,6 +584,7 @@ pub fn streamMake(conn: *QuicConnection, poll_peer: ?*QuicEndpoint) !*QuicStream
         .write_off = 0,
         .is_incoming = false,
     };
+    errdefer qs.deinit();
     try conn.streams_owned.append(alloc, qs);
     var i: u32 = 0;
     while (i < 100) : (i += 1) {
@@ -598,6 +600,7 @@ pub fn streamMakeUni(conn: *QuicConnection, poll_peer: ?*QuicEndpoint) !*QuicStr
     if (!connHandshakeReady(conn)) return error.HandshakeNotComplete;
     const alloc = conn.ep.allocator.*;
     const qs = try alloc.create(QuicStream);
+    errdefer alloc.destroy(qs);
     const sid = if (conn.client) |c| blk: {
         break :blk io.rawAllocateNextLocalUniStream(&c.conn);
     } else blk: {
@@ -613,6 +616,7 @@ pub fn streamMakeUni(conn: *QuicConnection, poll_peer: ?*QuicEndpoint) !*QuicStr
         .stream_send_off = 0,
         .is_incoming = false,
     };
+    errdefer qs.deinit();
     try conn.streams_owned.append(alloc, qs);
     var i: u32 = 0;
     while (i < 100) : (i += 1) {

--- a/src/wire/broadcast.zig
+++ b/src/wire/broadcast.zig
@@ -264,17 +264,26 @@ pub fn decodeBcast(allocator: std.mem.Allocator, buf: []const u8) Malformed!Bcas
         const inner = try decodeBytes(buf, allocator, &off);
         switch (field) {
             1 => {
-                if (which != null) return error.MalformedProtobuf;
+                if (which != null) {
+                    allocator.free(inner);
+                    return error.MalformedProtobuf;
+                }
                 which = .h;
                 payload = inner;
             },
             2 => {
-                if (which != null) return error.MalformedProtobuf;
+                if (which != null) {
+                    allocator.free(inner);
+                    return error.MalformedProtobuf;
+                }
                 which = .s;
                 payload = inner;
             },
             3 => {
-                if (which != null) return error.MalformedProtobuf;
+                if (which != null) {
+                    allocator.free(inner);
+                    return error.MalformedProtobuf;
+                }
                 which = .u;
                 payload = inner;
             },
@@ -424,12 +433,18 @@ pub fn decodeSess(allocator: std.mem.Allocator, buf: []const u8) Malformed!SessO
         const inner = try decodeBytes(buf, allocator, &off);
         switch (field) {
             1 => {
-                if (which != null) return error.MalformedProtobuf;
+                if (which != null) {
+                    allocator.free(inner);
+                    return error.MalformedProtobuf;
+                }
                 which = .open;
                 payload = inner;
             },
             2 => {
-                if (which != null) return error.MalformedProtobuf;
+                if (which != null) {
+                    allocator.free(inner);
+                    return error.MalformedProtobuf;
+                }
                 which = .upd;
                 payload = inner;
             },

--- a/src/wire/rs.zig
+++ b/src/wire/rs.zig
@@ -122,6 +122,7 @@ pub fn decodePreamble(allocator: std.mem.Allocator, buf: []const u8) Malformed!P
             4 => {
                 if (wire != 2) return error.MalformedProtobuf;
                 const b = try decodeBytes(buf, allocator, &off);
+                errdefer allocator.free(b);
                 try hashes.append(allocator, b);
             },
             5 => {
@@ -133,12 +134,21 @@ pub fn decodePreamble(allocator: std.mem.Allocator, buf: []const u8) Malformed!P
         }
     }
 
+    // Materialize owned outputs before the struct literal so that a failure
+    // in the default-hash allocation does not leak the finalized `hashes`.
+    const hashes_owned = try hashes.toOwnedSlice(allocator);
+    errdefer {
+        for (hashes_owned) |h| allocator.free(h);
+        allocator.free(hashes_owned);
+    }
+    const final_hash = hash orelse try allocator.dupe(u8, "");
+
     return .{
         .num_data = num_data,
         .num_parity = num_parity,
         .length = length,
-        .hashes = try hashes.toOwnedSlice(allocator),
-        .hash = hash orelse try allocator.dupe(u8, ""),
+        .hashes = hashes_owned,
+        .hash = final_hash,
     };
 }
 


### PR DESCRIPTION
## Summary

Adversarial review of the codebase surfaced a cluster of rare-error-path memory leaks and one undefined-behavior case. All of them share the same shape: an allocation succeeds but a follow-up step (usually `ArrayList.append`, a validation check, or a secondary allocation) fails and the intermediate allocation escapes cleanup.

### Fixes

- **`broadcast/channel_rs`** - `publish` / `attachRelaySession` allocated `member_ids` and `stats` arrays, then populated them in a loop. The `errdefer` iterated the full array, so a mid-loop `allocator.dupe` failure would free uninitialized slots (UB). Track a `populated` counter and only free `member_ids[0..populated]`.
- **`wire/broadcast`** - `decodeBcast` / `decodeSess` decoded a nested `inner` buffer and then rejected duplicate oneof fields without freeing it. Free `inner` before returning `error.MalformedProtobuf`.
- **`wire/rs`** - `decodePreamble` leaked the per-iteration hash buffer if `hashes.append` failed, and leaked the owned `hashes` slice if the final default-hash `dupe` failed. Add an `errdefer` for the per-iteration buffer and restructure the return so `hashes_owned` is covered before the default-hash allocation.
- **`discv5/protocol`** - Six encoders (`encodePing`, `encodePong`, `encodeFindNode`, `encodeNodes`, `encodeTalkReq`, `encodeTalkRes`) used the leaky `try items.append(a, try enc(a, ..))` pattern. Introduce an `appendOwned` helper that frees the buffer on append failure and route every append through it. Also add `errdefer` cleanup to `decodeFindNode` / `decodeNodes` so partially populated temporary lists are freed on error.
- **`discovery/enr`** - Same nested-try pattern in `buildContent` and `sign`. Add an `appendOwnedItem` helper and route all appends through it.
- **`transport/zquic_quic_shim`** - `streamMake` / `streamMakeUni` leaked the `QuicStream` allocation if `conn.streams_owned.append` failed. Add `errdefer alloc.destroy(qs)` and `errdefer qs.deinit()` between create and append.
- **`sim/gossipsub_rpc_pb`** - `decodeIHaveOwned`, `decodeIWantOwned`, `decodePruneOwned` and `decodeRpcOwned` leaked the freshly decoded child (duped bytes, or an owned sub-struct with its own nested allocations) when the outer list `append` failed. Register an `errdefer` on the intermediate value before appending.

No public API changes, no dependency changes, no behavior change on the happy path.

## Test plan

- [x] `zig fmt --check .`
- [x] `zig build test` (150 passed)
- [x] `zig build test-broadcast` (54 passed)
- [x] `zig build test-sim-rs` (22 passed)
- [x] `zig build test-sim-gossipsub` (23 passed)
- [x] `zig build test-quic` (44 passed)