### PR TITLE
transport,deps: bump zquic to v1.5.0

### DIFF
--- a/build.zig.zon
+++ b/build.zig.zon
@@ -15,8 +15,8 @@
     },
     .dependencies = .{
         .zquic = .{
-            .url = "https://github.com/ch4r10t33r/zquic/archive/refs/tags/v1.2.1.tar.gz",
-            .hash = "zquic-1.2.1-2zRc1AFCDwCgM1eFokgQYN4SnVIaeLzs5rSMwL1Nm8-Y",
+            .url = "https://github.com/ch4r10t33r/zquic/archive/refs/tags/v1.5.0.tar.gz",
+            .hash = "zquic-1.5.0-2zRc1LynDwAh1rU4KzmEmuSY9WKDP7qNgz7e8xI09uXn",
         },
     },
 }

--- a/src/transport/zquic_quic_shim.zig
+++ b/src/transport/zquic_quic_shim.zig
@@ -569,10 +569,10 @@ pub fn streamMake(conn: *QuicConnection, poll_peer: ?*QuicEndpoint) !*QuicStream
     if (!connHandshakeReady(conn)) return error.HandshakeNotComplete;
     const alloc = conn.ep.allocator.*;
     const sid = if (conn.client) |c| blk: {
-        break :blk io.rawAllocateNextLocalBidiStream(&c.conn);
+        break :blk try io.rawAllocateNextLocalBidiStream(&c.conn);
     } else blk: {
         const cs = conn.connStatePtr() orelse return error.StreamCreateFailed;
-        break :blk io.rawAllocateNextLocalBidiStream(cs);
+        break :blk try io.rawAllocateNextLocalBidiStream(cs);
     };
     const qs = try alloc.create(QuicStream);
     errdefer alloc.destroy(qs);
@@ -602,10 +602,10 @@ pub fn streamMakeUni(conn: *QuicConnection, poll_peer: ?*QuicEndpoint) !*QuicStr
     const qs = try alloc.create(QuicStream);
     errdefer alloc.destroy(qs);
     const sid = if (conn.client) |c| blk: {
-        break :blk io.rawAllocateNextLocalUniStream(&c.conn);
+        break :blk try io.rawAllocateNextLocalUniStream(&c.conn);
     } else blk: {
         const cs = conn.connStatePtr() orelse return error.StreamCreateFailed;
-        break :blk io.rawAllocateNextLocalUniStream(cs);
+        break :blk try io.rawAllocateNextLocalUniStream(cs);
     };
     qs.* = .{
         .conn = conn,


### PR DESCRIPTION
## Summary

Updates the `zquic` dependency from `v1.2.1` to [`v1.5.0`](https://github.com/ch4r10t33r/zquic/releases/tag/v1.5.0), picking up the security and correctness fixes landed in v1.3.x–v1.5.0:

- **Retry token replay window** (30 s) with hourly `retry_secret` rotation — bounds the blast radius of a leaked secret from "forever" to ~1 hour + 30 s (zquic #108).
- **`FINAL_SIZE_ERROR` enforcement** cross-checking `RESET_STREAM` `final_size` against any prior `STREAM+FIN` on the same stream (RFC 9000 §3.5/§11.3, zquic #109).
- **Non-minimal varint rejection** per RFC 9000 §16 (zquic #110).
- **Active connection ID limit** enforced per RFC 9000 §5.1.1 (zquic #111).
- **ACK range underflow** returns `FrameEncodingError` instead of saturating (RFC 9000 §19.3, zquic #112).
- **Stream-initiator violations** on `STREAM` frames are rejected (RFC 9000 §19.8, zquic #113).
- **Coalesced packet parser** hardening (zquic #115).

### API adjustment in `src/transport/zquic_quic_shim.zig`

`rawAllocateNextLocalBidiStream` / `rawAllocateNextLocalUniStream` now return `OpenLocalStreamError!u64` instead of `u64` — they enforce the peer-advertised `initial_max_streams_*`. Added `try` at both call sites in `streamMake` / `streamMakeUni` so `StreamLimitExceeded` propagates as a stream-create failure.

No other v1.5.0 API breaks bite us: `LossDetector.onAck`, `AckFrame.parse`, and `varint.DecodeError.NonMinimalEncoding` live in layers that zig-ethp2p doesn't call directly.

## Test plan

- [x] `zig fmt --check .`
- [x] `zig build test` (150 passed)
- [x] `zig build test-broadcast` (54 passed)
- [x] `zig build test-sim-rs` (22 passed)
- [x] `zig build test-sim-gossipsub` (23 passed)
- [x] `zig build test-quic` (44 passed)