### PR TITLE
chore: migrate to Zig 0.16.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ on:
     branches: [main, feature]
 
 env:
-  ZIG_VERSION: 0.15.1
+  ZIG_VERSION: 0.16.0
   # Normative prose under ethp2p `specs/`; keep in sync with `UPSTREAM.md` "Pinned revision".
   ETHP2P_SPECS_REF: 741d8d9cf682ff93b7d8eb56e0377ba8eea83a7e
 

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .zig-cache/
 zig-out/
 *.o
+zig-pkg/

--- a/build.zig
+++ b/build.zig
@@ -1,12 +1,25 @@
 const std = @import("std");
 
+const Bundle = struct {
+    quic_shim: *std.Build.Module,
+    zquic: *std.Build.Module,
+    compat: *std.Build.Module,
+};
+
 fn addZquicQuicModule(
     b: *std.Build,
     target: std.Build.ResolvedTarget,
     optimize: std.builtin.OptimizeMode,
-) struct { quic_shim: *std.Build.Module, zquic: *std.Build.Module } {
+) Bundle {
     const zquic_pkg = b.dependency("zquic", .{ .target = target, .optimize = optimize });
     const zquic_mod = zquic_pkg.module("zquic");
+
+    // Zig 0.15 → 0.16 std-library compatibility shims (see `src/compat.zig`).
+    const compat = b.createModule(.{
+        .root_source_file = b.path("src/compat.zig"),
+        .target = target,
+        .optimize = optimize,
+    });
 
     const quic_shim = b.addModule("quic", .{
         .root_source_file = b.path("src/transport/zquic_quic_shim.zig"),
@@ -14,12 +27,14 @@ fn addZquicQuicModule(
         .optimize = optimize,
     });
     quic_shim.addImport("zquic", zquic_mod);
+    quic_shim.addImport("compat", compat);
 
-    return .{ .quic_shim = quic_shim, .zquic = zquic_mod };
+    return .{ .quic_shim = quic_shim, .zquic = zquic_mod, .compat = compat };
 }
 
-fn wireModule(m: *std.Build.Module, quic_shim: *std.Build.Module) void {
-    m.addImport("quic", quic_shim);
+fn wireModule(m: *std.Build.Module, bundle: Bundle) void {
+    m.addImport("quic", bundle.quic_shim);
+    m.addImport("compat", bundle.compat);
 }
 
 pub fn build(b: *std.Build) void {
@@ -37,7 +52,7 @@ pub fn build(b: *std.Build) void {
         .target = target,
         .optimize = optimize,
     });
-    wireModule(mod, bundle.quic_shim);
+    wireModule(mod, bundle);
 
     const lib = b.addLibrary(.{
         .name = "zig_ethp2p",
@@ -50,7 +65,7 @@ pub fn build(b: *std.Build) void {
         .target = target,
         .optimize = optimize,
     });
-    wireModule(lib_tests_mod, bundle.quic_shim);
+    wireModule(lib_tests_mod, bundle);
     const lib_tests = b.addTest(.{ .root_module = lib_tests_mod });
     const run_lib_tests = b.addRunArtifact(lib_tests);
     const test_step = b.step("test", "Run library tests (full suite, same as local dev)");
@@ -78,7 +93,7 @@ pub fn build(b: *std.Build) void {
         .optimize = ci_opt,
         .sanitize_thread = ci_tsan,
     });
-    wireModule(broadcast_tests_mod, bundle_ci.quic_shim);
+    wireModule(broadcast_tests_mod, bundle_ci);
     const broadcast_tests = b.addTest(.{ .root_module = broadcast_tests_mod });
     const run_broadcast_tests = b.addRunArtifact(broadcast_tests);
     run_broadcast_tests.has_side_effects = true;
@@ -91,7 +106,7 @@ pub fn build(b: *std.Build) void {
         .optimize = ci_opt,
         .sanitize_thread = ci_tsan,
     });
-    wireModule(sim_rs_tests_mod, bundle_ci.quic_shim);
+    wireModule(sim_rs_tests_mod, bundle_ci);
     const sim_rs_tests = b.addTest(.{ .root_module = sim_rs_tests_mod });
     const run_sim_rs = b.addRunArtifact(sim_rs_tests);
     run_sim_rs.has_side_effects = true;
@@ -104,7 +119,7 @@ pub fn build(b: *std.Build) void {
         .optimize = ci_opt,
         .sanitize_thread = ci_tsan,
     });
-    wireModule(sim_gs_tests_mod, bundle_ci.quic_shim);
+    wireModule(sim_gs_tests_mod, bundle_ci);
     const sim_gs_tests = b.addTest(.{ .root_module = sim_gs_tests_mod });
     const run_sim_gs = b.addRunArtifact(sim_gs_tests);
     run_sim_gs.has_side_effects = true;
@@ -117,7 +132,7 @@ pub fn build(b: *std.Build) void {
         .optimize = ci_opt,
         .sanitize_thread = ci_tsan,
     });
-    wireModule(stress_ci_mod, bundle_ci.quic_shim);
+    wireModule(stress_ci_mod, bundle_ci);
     const run_stress_ci = b.addTest(.{ .root_module = stress_ci_mod });
     const run_stress_ci_run = b.addRunArtifact(run_stress_ci);
     run_stress_ci_run.setEnvironmentVariable("ZIG_ETHP2P_STRESS", "1");
@@ -130,7 +145,7 @@ pub fn build(b: *std.Build) void {
         .target = ci_target,
         .optimize = ci_opt,
     });
-    wireModule(quic_ci_mod, bundle_ci.quic_shim);
+    wireModule(quic_ci_mod, bundle_ci);
     const quic_ci_tests = b.addTest(.{ .root_module = quic_ci_mod });
     const run_quic_ci = b.addRunArtifact(quic_ci_tests);
     const test_quic_step = b.step("test-quic", "Transport QUIC tests (zquic handshake + stream framing)");

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -2,7 +2,7 @@
     .name = .zig_ethp2p,
     .version = "0.0.0",
     .fingerprint = 0xbeef30331296c64d,
-    .minimum_zig_version = "0.15.1",
+    .minimum_zig_version = "0.16.0",
     .paths = .{
         "build.zig",
         "build.zig.zon",
@@ -15,8 +15,8 @@
     },
     .dependencies = .{
         .zquic = .{
-            .url = "https://github.com/ch4r10t33r/zquic/archive/refs/tags/v1.5.0.tar.gz",
-            .hash = "zquic-1.5.0-2zRc1LynDwAh1rU4KzmEmuSY9WKDP7qNgz7e8xI09uXn",
+            .url = "https://github.com/ch4r10t33r/zquic/archive/refs/tags/v1.7.66.tar.gz",
+            .hash = "zquic-1.7.66-2zRc1EBVGACCVRmUoisIxS31Yt0feyFu80VYmgHn74Jw",
         },
     },
 }

--- a/src/broadcast/channel_rs.zig
+++ b/src/broadcast/channel_rs.zig
@@ -34,7 +34,7 @@ pub const ChannelRs = struct {
             .engine = engine,
             .id = id,
             .cfg = cfg,
-            .members = .{},
+            .members = .empty,
             .sessions = .{},
         };
     }

--- a/src/broadcast/engine_quic.zig
+++ b/src/broadcast/engine_quic.zig
@@ -63,8 +63,8 @@ pub const EngineQuicHost = struct {
         const st = self.peer.bcast_in orelse return error.MissingBcastIn;
         const buf = try drainUniStream(self.allocator, st, self.peer.ep, self.peer_ep);
         defer self.allocator.free(buf);
-        var fbs = std.io.fixedBufferStream(buf);
-        var owned = try bcast_stream.readBcastPeerHandshake(self.allocator, fbs.reader());
+        var fbs = std.Io.Reader.fixed(buf);
+        var owned = try bcast_stream.readBcastPeerHandshake(self.allocator, &fbs);
         defer owned.deinit(self.allocator);
         switch (owned) {
             .peer_handshake => |h| {
@@ -129,8 +129,8 @@ fn preambleOwnedToRs(allocator: std.mem.Allocator, owned: wire_rs.PreambleOwned)
 fn handleSessStream(host: *EngineQuicHost, st: *quic.QuicStream) !void {
     const buf = try drainUniStream(host.allocator, st, host.peer.ep, host.peer_ep);
     defer host.allocator.free(buf);
-    var fbs = std.io.fixedBufferStream(buf);
-    const r = fbs.reader();
+    var fbs = std.Io.Reader.fixed(buf);
+    const r = &fbs;
     const sel = try protocol.readSelectorByte(r);
     if (sel != .sess) return;
     var open_msg = try sess_stream.readSessSessionOpenAfterSelector(host.allocator, r);
@@ -154,8 +154,8 @@ fn handleChunkStream(host: *EngineQuicHost, st: *quic.QuicStream) !void {
 
     const buf = try drainUniStream(host.allocator, st, host.peer.ep, host.peer_ep);
     defer host.allocator.free(buf);
-    var fbs = std.io.fixedBufferStream(buf);
-    var chunk_in = try chunk_stream.readChunkStream(host.allocator, fbs.reader());
+    var fbs = std.Io.Reader.fixed(buf);
+    var chunk_in = try chunk_stream.readChunkStream(host.allocator, &fbs);
     defer chunk_in.deinit(host.allocator);
 
     const ch = host.engine.channelRs(chunk_in.header.channel) orelse return error.ChannelNotFound;
@@ -216,13 +216,12 @@ pub fn peerSendRsChunk(
     payload: []const u8,
 ) (std.mem.Allocator.Error || errors.Error)!void {
     const st = quic.streamMakeUni(pc.conn, poll_peer) catch return error.ChunkWriteFail;
-    var buf = std.ArrayList(u8).empty;
-    defer buf.deinit(pc.allocator);
+    var aw = std.Io.Writer.Allocating.init(pc.allocator);
+    defer aw.deinit();
     {
-        const w = buf.writer(pc.allocator);
-        chunk_stream.writeRsShardChunk(w, pc.allocator, channel_id, message_id, shard_index, payload) catch return error.ChunkMarshal;
+        chunk_stream.writeRsShardChunk(&aw.writer, pc.allocator, channel_id, message_id, shard_index, payload) catch return error.ChunkMarshal;
     }
-    try quic.streamQueueWrite(st, buf.items);
+    try quic.streamQueueWrite(st, aw.written());
     const peer_ep = poll_peer orelse pc.ep;
     quic.streamDrainWrites(st, peer_ep, 10_000) catch return error.ChunkWriteFail;
 }

--- a/src/broadcast/events.zig
+++ b/src/broadcast/events.zig
@@ -240,7 +240,7 @@ pub const ChannelEventQueue = struct {
     items: std.ArrayListUnmanaged(ChannelEvent),
 
     pub fn init(allocator: Allocator) ChannelEventQueue {
-        return .{ .allocator = allocator, .items = .{} };
+        return .{ .allocator = allocator, .items = .empty };
     }
 
     pub fn deinit(self: *ChannelEventQueue) void {
@@ -359,7 +359,7 @@ pub const PeerChunkOutbox = struct {
     items: std.ArrayListUnmanaged(PeerSendChunk),
 
     pub fn init(allocator: Allocator) PeerChunkOutbox {
-        return .{ .allocator = allocator, .items = .{} };
+        return .{ .allocator = allocator, .items = .empty };
     }
 
     pub fn deinit(self: *PeerChunkOutbox) void {

--- a/src/broadcast/relay_async_verify.zig
+++ b/src/broadcast/relay_async_verify.zig
@@ -6,6 +6,7 @@
 //! pin `&self.pool.pool` to the address used during `init`.
 
 const std = @import("std");
+const compat = @import("compat");
 const broadcast_types = @import("../layer/broadcast_types.zig");
 const dedup_registry_mod = @import("../layer/dedup_registry.zig");
 const rs_strategy = @import("../layer/rs_strategy.zig");
@@ -23,7 +24,7 @@ pub const RelayAsyncVerifier = struct {
     out_q: verify_queue_mod.VerifyQueue,
     pool: verify_workers_mod.VerifyWorkerPool,
     pending: std.AutoHashMapUnmanaged(u64, Pending) = .{},
-    mu: std.Thread.Mutex = .{},
+    mu: compat.Mutex = .{},
     next_handle: std.atomic.Value(u64) = .init(1),
 
     pub const Pending = struct {
@@ -187,7 +188,7 @@ pub const RelayAsyncVerifier = struct {
         });
         self.mu.unlock();
 
-        var wg: std.Thread.WaitGroup = .{};
+        var wg: compat.WaitGroup = .{};
         self.pool.scheduleWait(&wg, .{
             .handle = handle,
             .expected_hash = expected,

--- a/src/compat.zig
+++ b/src/compat.zig
@@ -503,7 +503,7 @@ pub const GetEnvError = error{ EnvironmentVariableNotFound, OutOfMemory };
 /// `/proc/self/environ` (no libc required); other targets use libc `getenv`.
 pub fn getEnvVarOwned(allocator: std.mem.Allocator, name: []const u8) GetEnvError![]u8 {
     if (comptime builtin.os.tag == .linux) {
-        const fd = system.open("/proc/self/environ", posix.O{ .ACCMODE = .RDONLY }, 0);
+        const fd = system.open("/proc/self/environ", posix.O{ .ACCMODE = .RDONLY }, @as(posix.mode_t, 0));
         if (posix.errno(fd) != .SUCCESS) return error.EnvironmentVariableNotFound;
         const handle: posix.fd_t = @intCast(fd);
         defer _ = system.close(handle);

--- a/src/compat.zig
+++ b/src/compat.zig
@@ -1,0 +1,581 @@
+//! Compatibility shims for the Zig 0.15 → 0.16 standard-library reorg.
+//!
+//! Zig 0.16 removed the high-level wrappers `std.net`, `std.crypto.random`,
+//! `std.process.getEnvVarOwned`, and the `socket`/`bind`/`sendto`/`recvfrom`/
+//! `close` helpers from `std.posix` (all folded into the new `std.Io`
+//! abstraction), and dropped `std.Thread.Mutex`/`std.Thread.Pool`.
+//!
+//! zig-ethp2p drives its own poll loop (via zquic) and does not need the
+//! `std.Io` async machinery — it just needs the raw syscalls and small value
+//! types back. This module reinstates a thin, dependency-free subset, mirroring
+//! the approach zquic itself takes in its own `compat.zig`.
+
+const std = @import("std");
+const builtin = @import("builtin");
+const posix = std.posix;
+const system = posix.system;
+
+inline fn checkRc(rc: anytype) posix.E {
+    return posix.errno(rc);
+}
+
+// ── socket / bind / sendto / recvfrom / close ───────────────────────────────
+
+pub const SocketError = error{
+    AccessDenied,
+    AddressFamilyUnsupported,
+    ProtocolUnsupportedBySystem,
+    ProtocolFamilyUnavailable,
+    ProcessFdQuotaExceeded,
+    SystemFdQuotaExceeded,
+    SystemResources,
+} || posix.UnexpectedError;
+
+pub fn socket(domain: u32, sock_type: u32, protocol: u32) SocketError!posix.socket_t {
+    // `std.posix.SOCK.NONBLOCK`/`CLOEXEC` are Zig-abstract flag bits, not the
+    // raw kernel values — the removed `std.posix.socket` translated them. Strip
+    // them off the type and apply them with `fcntl` after creation (portable
+    // across Linux and Darwin).
+    const want_nonblock = (sock_type & posix.SOCK.NONBLOCK) != 0;
+    const want_cloexec = (sock_type & posix.SOCK.CLOEXEC) != 0;
+    const raw_type = sock_type & ~@as(u32, posix.SOCK.NONBLOCK | posix.SOCK.CLOEXEC);
+
+    const rc = system.socket(domain, raw_type, protocol);
+    switch (checkRc(rc)) {
+        .SUCCESS => {},
+        .ACCES => return error.AccessDenied,
+        .AFNOSUPPORT => return error.AddressFamilyUnsupported,
+        .INVAL => return error.ProtocolFamilyUnavailable,
+        .MFILE => return error.ProcessFdQuotaExceeded,
+        .NFILE => return error.SystemFdQuotaExceeded,
+        .NOBUFS, .NOMEM => return error.SystemResources,
+        .PROTONOSUPPORT => return error.ProtocolUnsupportedBySystem,
+        else => |err| return posix.unexpectedErrno(err),
+    }
+    const fd: posix.socket_t = @intCast(rc);
+    if (want_nonblock) {
+        const fl = system.fcntl(fd, posix.F.GETFL, @as(usize, 0));
+        const o_nonblock: u32 = @bitCast(posix.O{ .NONBLOCK = true });
+        _ = system.fcntl(fd, posix.F.SETFL, fl | o_nonblock);
+    }
+    if (want_cloexec) {
+        const fdfl = system.fcntl(fd, posix.F.GETFD, @as(usize, 0));
+        _ = system.fcntl(fd, posix.F.SETFD, fdfl | posix.FD_CLOEXEC);
+    }
+    return fd;
+}
+
+pub const BindError = error{
+    AccessDenied,
+    AddressInUse,
+    AddressNotAvailable,
+    AlreadyBound,
+    SystemResources,
+} || posix.UnexpectedError;
+
+pub fn bind(sock: posix.socket_t, addr: *const posix.sockaddr, len: posix.socklen_t) BindError!void {
+    const rc = system.bind(sock, addr, len);
+    switch (checkRc(rc)) {
+        .SUCCESS => return,
+        .ACCES => return error.AccessDenied,
+        .ADDRINUSE => return error.AddressInUse,
+        .ADDRNOTAVAIL => return error.AddressNotAvailable,
+        .INVAL => return error.AlreadyBound,
+        .NOMEM => return error.SystemResources,
+        else => |err| return posix.unexpectedErrno(err),
+    }
+}
+
+pub const SendToError = error{
+    AccessDenied,
+    WouldBlock,
+    BrokenPipe,
+    MessageTooBig,
+    ConnectionResetByPeer,
+    NetworkUnreachable,
+    NetworkDown,
+    HostUnreachable,
+    SystemResources,
+    SocketUnconnected,
+    AddressFamilyUnsupported,
+} || posix.UnexpectedError;
+
+pub fn sendto(
+    sock: posix.socket_t,
+    buf: []const u8,
+    flags: u32,
+    dest_addr: ?*const posix.sockaddr,
+    addrlen: posix.socklen_t,
+) SendToError!usize {
+    while (true) {
+        const rc = system.sendto(sock, buf.ptr, buf.len, flags, dest_addr, addrlen);
+        switch (checkRc(rc)) {
+            .SUCCESS => return @intCast(rc),
+            .INTR => continue,
+            .ACCES => return error.AccessDenied,
+            .AGAIN => return error.WouldBlock,
+            .PIPE => return error.BrokenPipe,
+            .MSGSIZE => return error.MessageTooBig,
+            .CONNRESET => return error.ConnectionResetByPeer,
+            .NETUNREACH => return error.NetworkUnreachable,
+            .NETDOWN => return error.NetworkDown,
+            .HOSTUNREACH => return error.HostUnreachable,
+            .NOBUFS, .NOMEM => return error.SystemResources,
+            .NOTCONN => return error.SocketUnconnected,
+            .AFNOSUPPORT => return error.AddressFamilyUnsupported,
+            else => |err| return posix.unexpectedErrno(err),
+        }
+    }
+}
+
+pub const RecvFromError = error{
+    WouldBlock,
+    SystemResources,
+    ConnectionResetByPeer,
+    ConnectionRefused,
+    SocketUnconnected,
+} || posix.UnexpectedError;
+
+pub fn recvfrom(
+    sock: posix.socket_t,
+    buf: []u8,
+    flags: u32,
+    src_addr: ?*posix.sockaddr,
+    addrlen: ?*posix.socklen_t,
+) RecvFromError!usize {
+    while (true) {
+        const rc = system.recvfrom(sock, buf.ptr, buf.len, flags, src_addr, addrlen);
+        switch (checkRc(rc)) {
+            .SUCCESS => return @intCast(rc),
+            .INTR => continue,
+            .AGAIN => return error.WouldBlock,
+            .CONNRESET => return error.ConnectionResetByPeer,
+            .CONNREFUSED => return error.ConnectionRefused,
+            .NOTCONN => return error.SocketUnconnected,
+            .NOMEM, .NOBUFS => return error.SystemResources,
+            else => |err| return posix.unexpectedErrno(err),
+        }
+    }
+}
+
+pub fn close(sock: posix.socket_t) void {
+    _ = system.close(sock);
+}
+
+/// Sleep for `ns` nanoseconds (replaces the removed `std.Thread.sleep`, which
+/// in 0.16 became `std.Io.sleep` and requires an `Io` instance).
+pub fn sleepNs(ns: u64) void {
+    var req: posix.timespec = .{
+        .sec = @intCast(ns / std.time.ns_per_s),
+        .nsec = @intCast(ns % std.time.ns_per_s),
+    };
+    var rem: posix.timespec = undefined;
+    while (true) {
+        const rc = system.nanosleep(&req, &rem);
+        if (posix.errno(rc) == .INTR) {
+            req = rem;
+            continue;
+        }
+        return;
+    }
+}
+
+pub const ConnectError = error{
+    AccessDenied,
+    AddressInUse,
+    AddressNotAvailable,
+    ConnectionRefused,
+    ConnectionResetByPeer,
+    NetworkUnreachable,
+    HostUnreachable,
+    Timeout,
+    AlreadyConnected,
+    WouldBlock,
+    SystemResources,
+} || posix.UnexpectedError;
+
+pub fn connect(sock: posix.socket_t, addr: *const posix.sockaddr, len: posix.socklen_t) ConnectError!void {
+    const rc = system.connect(sock, addr, len);
+    switch (checkRc(rc)) {
+        .SUCCESS => return,
+        .ACCES, .PERM => return error.AccessDenied,
+        .ADDRINUSE => return error.AddressInUse,
+        .ADDRNOTAVAIL => return error.AddressNotAvailable,
+        .AGAIN, .INPROGRESS => return error.WouldBlock,
+        .ALREADY, .ISCONN => return error.AlreadyConnected,
+        .CONNREFUSED => return error.ConnectionRefused,
+        .CONNRESET => return error.ConnectionResetByPeer,
+        .HOSTUNREACH => return error.HostUnreachable,
+        .NETUNREACH => return error.NetworkUnreachable,
+        .TIMEDOUT => return error.Timeout,
+        .NOMEM, .NOBUFS => return error.SystemResources,
+        else => |err| return posix.unexpectedErrno(err),
+    }
+}
+
+pub const GetSockNameError = error{SystemResources} || posix.UnexpectedError;
+
+pub fn getsockname(sock: posix.socket_t, addr: *posix.sockaddr, len: *posix.socklen_t) GetSockNameError!void {
+    const rc = system.getsockname(sock, addr, len);
+    switch (checkRc(rc)) {
+        .SUCCESS => return,
+        .NOBUFS => return error.SystemResources,
+        else => |err| return posix.unexpectedErrno(err),
+    }
+}
+
+// ── net.Address / Ip4Address / Ip6Address ───────────────────────────────────
+//
+// Mirrors the pre-0.16 `std.net.Address` ergonomics zig-ethp2p relies on:
+// extern union over sockaddr with `.any`, `.in`, `.in6`, `initIp4`, `parseIp`,
+// `getPort`, `setPort`, `getOsSockLen`, `eql`.
+
+pub const Address = extern union {
+    any: posix.sockaddr,
+    in: posix.sockaddr.in,
+    in6: posix.sockaddr.in6,
+
+    pub fn initIp4(addr: [4]u8, port: u16) Address {
+        return .{ .in = .{
+            .family = posix.AF.INET,
+            .port = std.mem.nativeToBig(u16, port),
+            .addr = @bitCast(addr),
+            .zero = [_]u8{0} ** 8,
+        } };
+    }
+
+    pub fn parseIp4(buf: []const u8, port: u16) !Address {
+        var bytes: [4]u8 = undefined;
+        var idx: usize = 0;
+        var byte: u16 = 0;
+        var has_digit = false;
+        for (buf) |c| {
+            if (c == '.') {
+                if (!has_digit or idx >= 3) return error.InvalidIPAddressFormat;
+                bytes[idx] = @intCast(byte);
+                idx += 1;
+                byte = 0;
+                has_digit = false;
+            } else if (c >= '0' and c <= '9') {
+                byte = byte * 10 + (c - '0');
+                if (byte > 255) return error.InvalidIPAddressFormat;
+                has_digit = true;
+            } else {
+                return error.InvalidIPAddressFormat;
+            }
+        }
+        if (!has_digit or idx != 3) return error.InvalidIPAddressFormat;
+        bytes[3] = @intCast(byte);
+        return initIp4(bytes, port);
+    }
+
+    pub fn parseIp(buf: []const u8, port: u16) !Address {
+        return parseIp4(buf, port);
+    }
+
+    pub fn getPort(self: Address) u16 {
+        return switch (self.any.family) {
+            posix.AF.INET => std.mem.bigToNative(u16, self.in.port),
+            posix.AF.INET6 => std.mem.bigToNative(u16, self.in6.port),
+            else => 0,
+        };
+    }
+
+    pub fn setPort(self: *Address, port: u16) void {
+        switch (self.any.family) {
+            posix.AF.INET => self.in.port = std.mem.nativeToBig(u16, port),
+            posix.AF.INET6 => self.in6.port = std.mem.nativeToBig(u16, port),
+            else => {},
+        }
+    }
+
+    pub fn getOsSockLen(self: Address) posix.socklen_t {
+        return switch (self.any.family) {
+            posix.AF.INET => @sizeOf(posix.sockaddr.in),
+            posix.AF.INET6 => @sizeOf(posix.sockaddr.in6),
+            else => 0,
+        };
+    }
+
+    pub fn eql(a: Address, b: Address) bool {
+        if (a.any.family != b.any.family) return false;
+        return switch (a.any.family) {
+            posix.AF.INET => a.in.port == b.in.port and a.in.addr == b.in.addr,
+            posix.AF.INET6 => blk: {
+                if (a.in6.port != b.in6.port) break :blk false;
+                break :blk std.mem.eql(u8, &a.in6.addr, &b.in6.addr);
+            },
+            else => false,
+        };
+    }
+};
+
+/// Minimal stand-in for `std.net.Ip4Address` — zig-ethp2p only constructs it
+/// from raw bytes (ENR `ip` field) and reads back the address octets.
+pub const Ip4Address = struct {
+    sa: posix.sockaddr.in,
+
+    pub fn init(addr: [4]u8, port: u16) Ip4Address {
+        return .{ .sa = .{
+            .family = posix.AF.INET,
+            .port = std.mem.nativeToBig(u16, port),
+            .addr = @bitCast(addr),
+            .zero = [_]u8{0} ** 8,
+        } };
+    }
+};
+
+/// Minimal stand-in for `std.net.Ip6Address` (ENR `ip6` field).
+pub const Ip6Address = struct {
+    sa: posix.sockaddr.in6,
+
+    pub fn init(addr: [16]u8, port: u16) Ip6Address {
+        return .{ .sa = .{
+            .family = posix.AF.INET6,
+            .port = std.mem.nativeToBig(u16, port),
+            .flowinfo = 0,
+            .addr = addr,
+            .scope_id = 0,
+        } };
+    }
+};
+
+// ── CSPRNG (replaces removed `std.crypto.random`) ───────────────────────────
+
+fn osRandomBytes(buf: []u8) void {
+    if (comptime builtin.os.tag == .linux and !builtin.link_libc) {
+        var off: usize = 0;
+        while (off < buf.len) {
+            const rc = std.os.linux.getrandom(buf.ptr + off, buf.len - off, 0);
+            const e = posix.errno(rc);
+            if (e == .SUCCESS) {
+                off += @intCast(rc);
+            } else if (e == .INTR) {
+                continue;
+            } else {
+                @panic("getrandom failed");
+            }
+        }
+    } else if (comptime builtin.os.tag == .linux) {
+        var off: usize = 0;
+        while (off < buf.len) {
+            const n = std.c.getrandom(buf.ptr + off, buf.len - off, 0);
+            if (n > 0) {
+                off += @intCast(n);
+            } else {
+                if (posix.errno(n) == .INTR) continue;
+                @panic("getrandom failed");
+            }
+        }
+    } else {
+        std.c.arc4random_buf(buf.ptr, buf.len);
+    }
+}
+
+const RandomSrc = struct {
+    fn fill(_: *const RandomSrc, buf: []u8) void {
+        osRandomBytes(buf);
+    }
+};
+
+var random_src: RandomSrc = .{};
+
+/// Drop-in for the removed `std.crypto.random`. Backed by the OS CSPRNG.
+pub const random: std.Random = std.Random.init(&random_src, RandomSrc.fill);
+
+// ── Mutex (replaces removed `std.Thread.Mutex`) ─────────────────────────────
+//
+// A minimal test-and-test-and-set spinlock over `std.atomic.Value`. zig-ethp2p
+// only guards short critical sections in the async verify worker path, so a
+// spinlock is adequate and needs no `std.Io` instance.
+
+pub const Mutex = struct {
+    state: std.atomic.Value(u32) = std.atomic.Value(u32).init(0),
+
+    pub fn lock(self: *Mutex) void {
+        while (true) {
+            if (self.state.cmpxchgWeak(0, 1, .acquire, .monotonic) == null) return;
+            while (self.state.load(.monotonic) != 0) {
+                std.atomic.spinLoopHint();
+            }
+        }
+    }
+
+    pub fn tryLock(self: *Mutex) bool {
+        return self.state.cmpxchgStrong(0, 1, .acquire, .monotonic) == null;
+    }
+
+    pub fn unlock(self: *Mutex) void {
+        self.state.store(0, .release);
+    }
+};
+
+// ── WaitGroup / Pool (replace removed `std.Thread.WaitGroup` / `std.Thread.Pool`) ──
+//
+// zig-ethp2p's threaded work is limited to the async SHA256 verify path. A
+// minimal counter-based `WaitGroup` and a spawn-per-job `Pool` (both backed by
+// the still-present `std.Thread.spawn`) cover the small API surface used, with
+// no `std.Io` instance required. `n_jobs == 0` runs jobs inline on the caller.
+
+pub const WaitGroup = struct {
+    counter: std.atomic.Value(usize) = std.atomic.Value(usize).init(0),
+
+    pub fn start(self: *WaitGroup) void {
+        _ = self.counter.fetchAdd(1, .monotonic);
+    }
+
+    pub fn finish(self: *WaitGroup) void {
+        _ = self.counter.fetchSub(1, .release);
+    }
+
+    pub fn wait(self: *WaitGroup) void {
+        while (self.counter.load(.acquire) != 0) std.atomic.spinLoopHint();
+    }
+};
+
+pub const Pool = struct {
+    allocator: std.mem.Allocator = undefined,
+    n_jobs: usize = 0,
+    mu: Mutex = .{},
+    threads: std.ArrayList(std.Thread) = .empty,
+
+    pub const Options = struct {
+        allocator: std.mem.Allocator,
+        n_jobs: ?usize = null,
+    };
+
+    pub fn init(self: *Pool, options: Options) !void {
+        self.* = .{
+            .allocator = options.allocator,
+            .n_jobs = options.n_jobs orelse 0,
+        };
+    }
+
+    pub fn deinit(self: *Pool) void {
+        for (self.threads.items) |t| t.join();
+        self.threads.deinit(self.allocator);
+        self.* = undefined;
+    }
+
+    fn track(self: *Pool, t: std.Thread) void {
+        self.mu.lock();
+        defer self.mu.unlock();
+        self.threads.append(self.allocator, t) catch t.detach();
+    }
+
+    pub fn spawn(self: *Pool, comptime func: anytype, args: anytype) !void {
+        if (self.n_jobs == 0) {
+            @call(.auto, func, args);
+            return;
+        }
+        const t = try std.Thread.spawn(.{}, func, args);
+        self.track(t);
+    }
+
+    pub fn spawnWg(self: *Pool, wg: *WaitGroup, comptime func: anytype, args: anytype) void {
+        wg.start();
+        if (self.n_jobs == 0) {
+            @call(.auto, func, args);
+            wg.finish();
+            return;
+        }
+        const Wrap = struct {
+            fn run(w: *WaitGroup, inner: @TypeOf(args)) void {
+                @call(.auto, func, inner);
+                w.finish();
+            }
+        };
+        const t = std.Thread.spawn(.{}, Wrap.run, .{ wg, args }) catch {
+            @call(.auto, func, args);
+            wg.finish();
+            return;
+        };
+        self.track(t);
+    }
+};
+
+// ── Environment (replaces removed `std.process.getEnvVarOwned`) ──────────────
+
+pub const GetEnvError = error{ EnvironmentVariableNotFound, OutOfMemory };
+
+/// Returns an owned copy of environment variable `name`, or
+/// `error.EnvironmentVariableNotFound` when unset. Linux reads
+/// `/proc/self/environ` (no libc required); other targets use libc `getenv`.
+pub fn getEnvVarOwned(allocator: std.mem.Allocator, name: []const u8) GetEnvError![]u8 {
+    if (comptime builtin.os.tag == .linux) {
+        const fd = system.open("/proc/self/environ", posix.O{ .ACCMODE = .RDONLY }, 0);
+        if (posix.errno(fd) != .SUCCESS) return error.EnvironmentVariableNotFound;
+        const handle: posix.fd_t = @intCast(fd);
+        defer _ = system.close(handle);
+
+        var contents: std.ArrayList(u8) = .empty;
+        defer contents.deinit(allocator);
+        var buf: [4096]u8 = undefined;
+        while (true) {
+            const rc = system.read(handle, &buf, buf.len);
+            if (posix.errno(rc) != .SUCCESS) return error.EnvironmentVariableNotFound;
+            const n: usize = @intCast(rc);
+            if (n == 0) break;
+            contents.appendSlice(allocator, buf[0..n]) catch return error.OutOfMemory;
+        }
+        var entries = std.mem.splitScalar(u8, contents.items, 0);
+        while (entries.next()) |entry| {
+            const eq = std.mem.indexOfScalar(u8, entry, '=') orelse continue;
+            if (std.mem.eql(u8, entry[0..eq], name)) {
+                return allocator.dupe(u8, entry[eq + 1 ..]) catch error.OutOfMemory;
+            }
+        }
+        return error.EnvironmentVariableNotFound;
+    } else {
+        var name_buf: [256]u8 = undefined;
+        if (name.len >= name_buf.len) return error.EnvironmentVariableNotFound;
+        @memcpy(name_buf[0..name.len], name);
+        name_buf[name.len] = 0;
+        const val = std.c.getenv(@ptrCast(&name_buf)) orelse return error.EnvironmentVariableNotFound;
+        return allocator.dupe(u8, std.mem.span(val)) catch error.OutOfMemory;
+    }
+}
+
+/// Owned absolute path of the current working directory (replaces the removed
+/// `std.fs.cwd().realpathAlloc(".")` / `std.posix.getcwd`).
+pub fn getCwdAlloc(allocator: std.mem.Allocator) ![]u8 {
+    var buf: [4096]u8 = undefined;
+    if (comptime builtin.os.tag == .linux and !builtin.link_libc) {
+        const rc = std.os.linux.getcwd(&buf, buf.len);
+        if (posix.errno(rc) != .SUCCESS) return error.CurrentWorkingDirectoryUnlinked;
+        const path = std.mem.sliceTo(&buf, 0);
+        return allocator.dupe(u8, path);
+    } else {
+        if (std.c.getcwd(&buf, buf.len) == null) return error.CurrentWorkingDirectoryUnlinked;
+        return allocator.dupe(u8, std.mem.sliceTo(&buf, 0));
+    }
+}
+
+test "Address round-trips ipv4 + port" {
+    var a = Address.initIp4(.{ 127, 0, 0, 1 }, 30303);
+    try std.testing.expectEqual(@as(u16, 30303), a.getPort());
+    a.setPort(40404);
+    try std.testing.expectEqual(@as(u16, 40404), a.getPort());
+    const b = try Address.parseIp("127.0.0.1", 40404);
+    try std.testing.expect(a.eql(b));
+}
+
+test "Mutex guards a counter across threads" {
+    var m: Mutex = .{};
+    var n: usize = 0;
+    const Ctx = struct {
+        fn bump(mu: *Mutex, counter: *usize) void {
+            var i: usize = 0;
+            while (i < 1000) : (i += 1) {
+                mu.lock();
+                counter.* += 1;
+                mu.unlock();
+            }
+        }
+    };
+    const t0 = try std.Thread.spawn(.{}, Ctx.bump, .{ &m, &n });
+    const t1 = try std.Thread.spawn(.{}, Ctx.bump, .{ &m, &n });
+    t0.join();
+    t1.join();
+    try std.testing.expectEqual(@as(usize, 2000), n);
+}

--- a/src/discovery/discv5/crypto.zig
+++ b/src/discovery/discv5/crypto.zig
@@ -8,6 +8,7 @@
 //! Packets are encrypted with AES-128-GCM.
 
 const std = @import("std");
+const compat = @import("compat");
 
 const aes_gcm = std.crypto.aead.aes_gcm.Aes128Gcm;
 const hkdf = std.crypto.kdf.hkdf.HkdfSha256;
@@ -168,7 +169,9 @@ pub fn generateEphemeralKeypair(
     privkey_out: *[privkey_len]u8,
     pubkey_out: *[pubkey_len]u8,
 ) Secp256k1Error!void {
-    const kp = EcdsaK.KeyPair.generate();
+    var seed: [EcdsaK.KeyPair.seed_length]u8 = undefined;
+    compat.random.bytes(&seed);
+    const kp = EcdsaK.KeyPair.generateDeterministic(seed) catch return error.Secp256k1Error;
     privkey_out.* = kp.secret_key.toBytes();
     pubkey_out.* = kp.public_key.toCompressedSec1();
 }

--- a/src/discovery/discv5/node.zig
+++ b/src/discovery/discv5/node.zig
@@ -11,6 +11,7 @@
 //! the event loop.  The caller provides a send callback for outbound datagrams.
 
 const std = @import("std");
+const compat = @import("compat");
 const table = @import("table.zig");
 const session = @import("session.zig");
 const protocol = @import("protocol.zig");
@@ -25,7 +26,7 @@ const ethp2p_enr = @import("../enr/ethp2p.zig");
 
 pub const Config = struct {
     /// UDP address to listen on.
-    listen_addr: std.net.Address = std.net.Address.initIp4(.{ 0, 0, 0, 0 }, 0),
+    listen_addr: compat.Address = compat.Address.initIp4(.{ 0, 0, 0, 0 }, 0),
     /// Local secp256k1 private key (32-byte scalar).
     local_privkey: [crypto.privkey_len]u8 = [_]u8{0} ** crypto.privkey_len,
     /// How often to refresh each bucket (ms).
@@ -54,7 +55,7 @@ const PendingRequest = struct {
 /// against an inbound WHOAREYOU challenge.
 const PendingChallenge = struct {
     target: table.NodeId,
-    addr: std.net.Address,
+    addr: compat.Address,
     nonce: [12]u8,
     /// Plaintext message to re-encrypt inside the Handshake body.
     plain_msg: ?[]const u8,
@@ -88,9 +89,9 @@ pub const Node = struct {
     owns_socket: bool = true,
 
     /// In-flight requests.
-    pending: std.ArrayListUnmanaged(PendingRequest) = .{},
+    pending: std.ArrayListUnmanaged(PendingRequest) = .empty,
     /// Outbound ordinary packets awaiting WHOAREYOU correlation.
-    challenge_pending: std.ArrayListUnmanaged(PendingChallenge) = .{},
+    challenge_pending: std.ArrayListUnmanaged(PendingChallenge) = .empty,
     /// Active lookup (only one at a time for simplicity).
     active_lookup: ?Lookup = null,
     /// Cache of ENR capabilities by NodeId (populated from NODES responses).
@@ -105,7 +106,7 @@ pub const Node = struct {
 
     /// Outbound send callback.
     /// The caller can set this to forward datagrams via their own UDP loop.
-    send_fn: ?*const fn (addr: std.net.Address, data: []const u8) void = null,
+    send_fn: ?*const fn (addr: compat.Address, data: []const u8) void = null,
 
     pub fn init(allocator: std.mem.Allocator, config: Config) crypto.Secp256k1Error!Node {
         var pubkey: [crypto.pubkey_len]u8 = undefined;
@@ -124,7 +125,7 @@ pub const Node = struct {
     pub fn deinit(self: *Node) void {
         if (self.owns_socket) {
             if (self.socket) |sock| {
-                std.posix.close(sock);
+                compat.close(sock);
                 self.socket = null;
             }
         }
@@ -140,12 +141,12 @@ pub const Node = struct {
     /// Bind a new UDP socket and start the node.
     pub fn start(self: *Node) !void {
         const addr = self.config.listen_addr;
-        const sock = try std.posix.socket(
+        const sock = try compat.socket(
             addr.any.family,
             std.posix.SOCK.DGRAM | std.posix.SOCK.NONBLOCK,
             0,
         );
-        try std.posix.bind(sock, &addr.any, addr.getOsSockLen());
+        try compat.bind(sock, &addr.any, addr.getOsSockLen());
         self.socket = sock;
         self.owns_socket = true;
         self.state = .running;
@@ -164,7 +165,7 @@ pub const Node = struct {
     pub fn stop(self: *Node) void {
         if (self.owns_socket) {
             if (self.socket) |sock| {
-                std.posix.close(sock);
+                compat.close(sock);
             }
         }
         self.socket = null;
@@ -206,7 +207,7 @@ pub const Node = struct {
         var from_len: std.posix.socklen_t = @sizeOf(std.posix.sockaddr);
 
         while (true) {
-            const n = std.posix.recvfrom(
+            const n = compat.recvfrom(
                 sock,
                 &dgram,
                 std.posix.MSG.DONTWAIT,
@@ -214,7 +215,7 @@ pub const Node = struct {
                 &from_len,
             ) catch break; // EAGAIN/EWOULDBLOCK → no more datagrams
 
-            const from = std.net.Address{ .any = from_addr };
+            const from = compat.Address{ .any = from_addr };
             self.handleDatagram(dgram[0..n], from);
         }
     }
@@ -223,7 +224,7 @@ pub const Node = struct {
     // Inbound packet dispatch
     // -----------------------------------------------------------------------
 
-    fn handleDatagram(self: *Node, data: []const u8, from: std.net.Address) void {
+    fn handleDatagram(self: *Node, data: []const u8, from: compat.Address) void {
         var hdr_buf: [packet.static_header_len + 300 + 32]u8 = undefined;
         const pkt = packet.decode(data, self.local_id, &hdr_buf) catch return;
 
@@ -238,7 +239,7 @@ pub const Node = struct {
     /// (e.g. a shared UDP socket).  Returns `true` when the datagram was valid
     /// discv5 and has been processed; `false` when it should be forwarded elsewhere
     /// (e.g. to a co-located QUIC endpoint).
-    pub fn injectDatagram(self: *Node, data: []const u8, from: std.net.Address) bool {
+    pub fn injectDatagram(self: *Node, data: []const u8, from: compat.Address) bool {
         var hdr_buf: [packet.static_header_len + 300 + 32]u8 = undefined;
         const pkt = packet.decode(data, self.local_id, &hdr_buf) catch return false;
         switch (pkt) {
@@ -254,7 +255,7 @@ pub const Node = struct {
         hdr: packet.PacketHeader,
         auth: packet.OrdinaryAuthData,
         encrypted_body: []const u8,
-        from: std.net.Address,
+        from: compat.Address,
     ) void {
         // Look up session keys for src_id.
         const sess = self.sessions.get(auth.src_id) orelse {
@@ -289,7 +290,7 @@ pub const Node = struct {
         hdr: packet.PacketHeader,
         auth: packet.WhoareyouAuthData,
         raw_datagram: []const u8,
-        from: std.net.Address,
+        from: compat.Address,
     ) void {
         // Correlate by matching the WHOAREYOU's nonce against nonces of
         // packets we recently sent.
@@ -327,14 +328,14 @@ pub const Node = struct {
         if (pending.plain_msg) |msg| {
             if (msg.len + crypto.aes_tag_len > ct_buf.len) return;
             var nonce: [crypto.aes_nonce_len]u8 = undefined;
-            std.crypto.random.bytes(&nonce);
+            compat.random.bytes(&nonce);
             crypto.encryptAesGcm(ct_buf[0 .. msg.len + crypto.aes_tag_len], msg, &hdr.nonce, keys.initiator_key, nonce);
             ct_len = msg.len + crypto.aes_tag_len;
         }
 
         // Encode and send the Handshake packet.
         var iv: [packet.masking_iv_len]u8 = undefined;
-        std.crypto.random.bytes(&iv);
+        compat.random.bytes(&iv);
         var dgram: [packet.max_datagram_len]u8 = undefined;
         const n = packet.encodeHandshake(&dgram, iv, pending.target, hdr.nonce, .{
             .src_id = self.local_id,
@@ -366,7 +367,7 @@ pub const Node = struct {
         hdr: packet.PacketHeader,
         auth: packet.HandshakeAuthData,
         encrypted_body: []const u8,
-        from: std.net.Address,
+        from: compat.Address,
     ) void {
         // The session for this peer must exist in awaiting_handshake state
         // (created by sendWhoareyou). It holds the id_nonce and raw
@@ -401,7 +402,7 @@ pub const Node = struct {
         hdr: packet.PacketHeader,
         auth: packet.HandshakeAuthData,
         encrypted_body: []const u8,
-        from: std.net.Address,
+        from: compat.Address,
         sess: *session.Session,
     ) void {
         // ECDH shared secret using our static key and their ephemeral key.
@@ -435,7 +436,7 @@ pub const Node = struct {
         hdr: packet.PacketHeader,
         auth: packet.HandshakeAuthData,
         encrypted_body: []const u8,
-        from: std.net.Address,
+        from: compat.Address,
         sess: *session.Session,
     ) void {
         // Without a known static pubkey we cannot verify the id-signature
@@ -561,7 +562,7 @@ pub const Node = struct {
             // Add to routing table with a placeholder UDP address.
             const entry = table.Entry{
                 .node_id = node_id,
-                .udp_addr = std.net.Address.initIp4(.{ 0, 0, 0, 0 }, 0),
+                .udp_addr = compat.Address.initIp4(.{ 0, 0, 0, 0 }, 0),
                 .enr_seq = rec.seq,
                 .last_seen_ns = self.last_poll_ns,
             };
@@ -574,7 +575,7 @@ pub const Node = struct {
         }
     }
 
-    fn processInboundEnr(self: *Node, raw: []const u8, from: std.net.Address) void {
+    fn processInboundEnr(self: *Node, raw: []const u8, from: compat.Address) void {
         var rec = enr_mod.decode(self.allocator, raw) catch return;
         defer rec.deinit();
 
@@ -618,18 +619,18 @@ pub const Node = struct {
         self: *Node,
         node_id: table.NodeId,
         plain: []const u8,
-        addr: std.net.Address,
+        addr: compat.Address,
         sess: *session.Session,
     ) void {
         var nonce: [crypto.aes_nonce_len]u8 = undefined;
-        std.crypto.random.bytes(&nonce);
+        compat.random.bytes(&nonce);
 
         var ct: [packet.max_datagram_len]u8 = undefined;
         if (plain.len + crypto.aes_tag_len > ct.len) return;
         crypto.encryptAesGcm(ct[0 .. plain.len + crypto.aes_tag_len], plain, &nonce, sess.keys.initiator_key, nonce);
 
         var iv: [packet.masking_iv_len]u8 = undefined;
-        std.crypto.random.bytes(&iv);
+        compat.random.bytes(&iv);
 
         var dgram: [packet.max_datagram_len]u8 = undefined;
         const n = packet.encodeOrdinary(
@@ -662,18 +663,18 @@ pub const Node = struct {
         self: *Node,
         node_id: table.NodeId,
         plain: []const u8,
-        addr: std.net.Address,
+        addr: compat.Address,
     ) void {
         var nonce: [crypto.aes_nonce_len]u8 = undefined;
-        std.crypto.random.bytes(&nonce);
+        compat.random.bytes(&nonce);
 
         // Random ciphertext — the remote won't decrypt this; it will reply
         // with WHOAREYOU.
         var random_ct: [44]u8 = undefined;
-        std.crypto.random.bytes(&random_ct);
+        compat.random.bytes(&random_ct);
 
         var iv: [packet.masking_iv_len]u8 = undefined;
-        std.crypto.random.bytes(&iv);
+        compat.random.bytes(&iv);
 
         var dgram: [packet.max_datagram_len]u8 = undefined;
         const n = packet.encodeOrdinary(
@@ -703,12 +704,12 @@ pub const Node = struct {
         self: *Node,
         dest_id: table.NodeId,
         challenge_nonce: [12]u8,
-        dest_addr: std.net.Address,
+        dest_addr: compat.Address,
     ) void {
         var id_nonce: [16]u8 = undefined;
-        std.crypto.random.bytes(&id_nonce);
+        compat.random.bytes(&id_nonce);
         var iv: [packet.masking_iv_len]u8 = undefined;
-        std.crypto.random.bytes(&iv);
+        compat.random.bytes(&iv);
 
         var dgram: [packet.max_datagram_len]u8 = undefined;
         const n = packet.encodeWhoareyou(&dgram, iv, dest_id, challenge_nonce, id_nonce, 0) catch return;
@@ -723,7 +724,7 @@ pub const Node = struct {
         self.sendDatagram(dest_addr, dgram[0..n]);
     }
 
-    fn sendPing(self: *Node, node_id: table.NodeId, addr: std.net.Address) void {
+    fn sendPing(self: *Node, node_id: table.NodeId, addr: compat.Address) void {
         _ = addr;
         const req_id = self.nextRequestId();
         const msg = protocol.Ping{ .request_id = req_id, .enr_seq = 1 };
@@ -755,13 +756,13 @@ pub const Node = struct {
         }) catch {};
     }
 
-    fn sendDatagram(self: *Node, addr: std.net.Address, data: []const u8) void {
+    fn sendDatagram(self: *Node, addr: compat.Address, data: []const u8) void {
         if (self.send_fn) |f| {
             f(addr, data);
             return;
         }
         if (self.socket) |sock| {
-            _ = std.posix.sendto(sock, data, 0, &addr.any, addr.getOsSockLen()) catch {};
+            _ = compat.sendto(sock, data, 0, &addr.any, addr.getOsSockLen()) catch {};
         }
     }
 
@@ -906,7 +907,7 @@ test "node init and start/stop" {
     const gpa = std.testing.allocator;
     var node = try Node.init(gpa, .{
         .local_privkey = [_]u8{1} ** 32,
-        .listen_addr = std.net.Address.initIp4(.{ 127, 0, 0, 1 }, 0),
+        .listen_addr = compat.Address.initIp4(.{ 127, 0, 0, 1 }, 0),
     });
     defer node.deinit();
 
@@ -936,7 +937,7 @@ test "addBootstrap populates routing table" {
 
     node.addBootstrap(.{
         .node_id = [_]u8{0xff} ** 32,
-        .udp_addr = std.net.Address.initIp4(.{ 127, 0, 0, 1 }, 9000),
+        .udp_addr = compat.Address.initIp4(.{ 127, 0, 0, 1 }, 9000),
         .enr_seq = 1,
         .last_seen_ns = 0,
     });
@@ -951,7 +952,7 @@ test "queryByCapability returns all nodes when scheme_mask=0" {
     for (0..5) |i| {
         node.addBootstrap(.{
             .node_id = [_]u8{@intCast(i + 1)} ** 32,
-            .udp_addr = std.net.Address.initIp4(.{ 127, 0, 0, 1 }, @intCast(9000 + i)),
+            .udp_addr = compat.Address.initIp4(.{ 127, 0, 0, 1 }, @intCast(9000 + i)),
             .enr_seq = 1,
             .last_seen_ns = 0,
         });
@@ -970,21 +971,21 @@ test "queryByCapability returns all nodes when scheme_mask=0" {
 const TestDatagram = struct {
     data: [packet.max_datagram_len]u8,
     len: usize,
-    addr: std.net.Address,
+    addr: compat.Address,
 };
 
 /// Simple capture buffer shared between two test nodes.
 var test_capture_a: ?TestDatagram = null;
 var test_capture_b: ?TestDatagram = null;
 
-fn captureSendA(_: std.net.Address, data: []const u8) void {
+fn captureSendA(_: compat.Address, data: []const u8) void {
     var d: TestDatagram = undefined;
     @memcpy(d.data[0..data.len], data);
     d.len = data.len;
     test_capture_a = d;
 }
 
-fn captureSendB(_: std.net.Address, data: []const u8) void {
+fn captureSendB(_: compat.Address, data: []const u8) void {
     var d: TestDatagram = undefined;
     @memcpy(d.data[0..data.len], data);
     d.len = data.len;
@@ -1016,8 +1017,8 @@ fn makeTestNodePair(gpa: std.mem.Allocator) !TestNodePair {
     try crypto.generatePubkey(&pub_b, priv_b);
     const id_b = try crypto.nodeIdFromPubkey(pub_b);
 
-    const addr_a = std.net.Address.initIp4(.{ 127, 0, 0, 1 }, 9001);
-    const addr_b = std.net.Address.initIp4(.{ 127, 0, 0, 1 }, 9002);
+    const addr_a = compat.Address.initIp4(.{ 127, 0, 0, 1 }, 9001);
+    const addr_b = compat.Address.initIp4(.{ 127, 0, 0, 1 }, 9002);
 
     const a = try gpa.create(Node);
     a.* = try Node.init(gpa, .{ .local_privkey = priv_a });
@@ -1059,7 +1060,7 @@ test "WHOAREYOU nonce echoes challenge nonce" {
     var pub_b: [crypto.pubkey_len]u8 = undefined;
     try crypto.generatePubkey(&pub_b, priv_b);
     const id_b = try crypto.nodeIdFromPubkey(pub_b);
-    pair.a.sendPing(id_b, std.net.Address.initIp4(.{ 127, 0, 0, 1 }, 9002));
+    pair.a.sendPing(id_b, compat.Address.initIp4(.{ 127, 0, 0, 1 }, 9002));
 
     // A's outbound packet was captured in test_capture_b.
     const initial = test_capture_b orelse return error.NoDatagram;
@@ -1074,7 +1075,7 @@ test "WHOAREYOU nonce echoes challenge nonce" {
 
     // B receives the packet — should respond with WHOAREYOU.
     test_capture_a = null;
-    pair.b.handleDatagram(initial.data[0..initial.len], std.net.Address.initIp4(.{ 127, 0, 0, 1 }, 9001));
+    pair.b.handleDatagram(initial.data[0..initial.len], compat.Address.initIp4(.{ 127, 0, 0, 1 }, 9001));
 
     const whoareyou = test_capture_a orelse return error.NoWhoareyou;
     var hdr_buf2: [packet.static_header_len + 300 + 32]u8 = undefined;
@@ -1107,7 +1108,7 @@ test "full handshake roundtrip establishes session" {
     const id_a = try crypto.nodeIdFromPubkey(pub_a);
 
     // Step 1: A sends PING to B (no session -> sends random packet).
-    pair.a.sendPing(id_b, std.net.Address.initIp4(.{ 127, 0, 0, 1 }, 9002));
+    pair.a.sendPing(id_b, compat.Address.initIp4(.{ 127, 0, 0, 1 }, 9002));
     const pkt1 = test_capture_b orelse return error.NoDatagram;
 
     // Verify A recorded a pending challenge.
@@ -1115,7 +1116,7 @@ test "full handshake roundtrip establishes session" {
 
     // Step 2: B receives random packet -> sends WHOAREYOU.
     test_capture_a = null;
-    pair.b.handleDatagram(pkt1.data[0..pkt1.len], std.net.Address.initIp4(.{ 127, 0, 0, 1 }, 9001));
+    pair.b.handleDatagram(pkt1.data[0..pkt1.len], compat.Address.initIp4(.{ 127, 0, 0, 1 }, 9001));
     const pkt2 = test_capture_a orelse return error.NoWhoareyou;
 
     // Verify B has a session in awaiting_handshake state.
@@ -1125,7 +1126,7 @@ test "full handshake roundtrip establishes session" {
 
     // Step 3: A receives WHOAREYOU -> sends Handshake.
     test_capture_b = null;
-    pair.a.handleDatagram(pkt2.data[0..pkt2.len], std.net.Address.initIp4(.{ 127, 0, 0, 1 }, 9002));
+    pair.a.handleDatagram(pkt2.data[0..pkt2.len], compat.Address.initIp4(.{ 127, 0, 0, 1 }, 9002));
     const pkt3 = test_capture_b orelse return error.NoHandshake;
 
     // Verify A established a session.
@@ -1137,7 +1138,7 @@ test "full handshake roundtrip establishes session" {
     try std.testing.expectEqual(@as(usize, 0), pair.a.challenge_pending.items.len);
 
     // Step 4: B receives Handshake -> establishes session.
-    pair.b.handleDatagram(pkt3.data[0..pkt3.len], std.net.Address.initIp4(.{ 127, 0, 0, 1 }, 9001));
+    pair.b.handleDatagram(pkt3.data[0..pkt3.len], compat.Address.initIp4(.{ 127, 0, 0, 1 }, 9001));
     const sess_b2 = pair.b.sessions.get(id_a);
     try std.testing.expect(sess_b2 != null);
     try std.testing.expectEqual(session.SessionState.established, sess_b2.?.state);
@@ -1149,7 +1150,7 @@ test "pending challenge expiry removes stale entries" {
     defer node.deinit();
 
     const target_id = [_]u8{0xaa} ** 32;
-    const addr = std.net.Address.initIp4(.{ 127, 0, 0, 1 }, 9000);
+    const addr = compat.Address.initIp4(.{ 127, 0, 0, 1 }, 9000);
 
     node.challenge_pending.append(gpa, .{
         .target = target_id,

--- a/src/discovery/discv5/protocol.zig
+++ b/src/discovery/discv5/protocol.zig
@@ -134,7 +134,7 @@ fn decodeReqId(item: []const u8) DecodeError!u64 {
 // ---------------------------------------------------------------------------
 
 pub fn encodePing(allocator: std.mem.Allocator, msg: Ping) EncodeError![]u8 {
-    var items = std.ArrayListUnmanaged([]u8){};
+    var items = std.ArrayListUnmanaged([]u8).empty;
     defer {
         for (items.items) |it| allocator.free(it);
         items.deinit(allocator);
@@ -173,7 +173,7 @@ pub fn decodePing(allocator: std.mem.Allocator, data: []const u8) DecodeError!Pi
 // ---------------------------------------------------------------------------
 
 pub fn encodePong(allocator: std.mem.Allocator, msg: Pong) EncodeError![]u8 {
-    var items = std.ArrayListUnmanaged([]u8){};
+    var items = std.ArrayListUnmanaged([]u8).empty;
     defer {
         for (items.items) |it| allocator.free(it);
         items.deinit(allocator);
@@ -226,7 +226,7 @@ pub fn decodePong(allocator: std.mem.Allocator, data: []const u8) (DecodeError |
 // ---------------------------------------------------------------------------
 
 pub fn encodeFindNode(allocator: std.mem.Allocator, msg: FindNode) EncodeError![]u8 {
-    var items = std.ArrayListUnmanaged([]u8){};
+    var items = std.ArrayListUnmanaged([]u8).empty;
     defer {
         for (items.items) |it| allocator.free(it);
         items.deinit(allocator);
@@ -235,7 +235,7 @@ pub fn encodeFindNode(allocator: std.mem.Allocator, msg: FindNode) EncodeError![
     try appendOwned(&items, allocator, try encodeReqId(allocator, msg.request_id));
 
     // distances is a list of u8 values.
-    var dist_items = std.ArrayListUnmanaged([]u8){};
+    var dist_items = std.ArrayListUnmanaged([]u8).empty;
     defer {
         for (dist_items.items) |it| allocator.free(it);
         dist_items.deinit(allocator);
@@ -264,7 +264,7 @@ pub fn decodeFindNode(allocator: std.mem.Allocator, data: []const u8) (DecodeErr
     const dists_item = try rlpDecode(rest);
     const dists_payload = try enr_mod.rlpListPayload(dists_item.item);
 
-    var dist_list = std.ArrayListUnmanaged(u8){};
+    var dist_list = std.ArrayListUnmanaged(u8).empty;
     errdefer dist_list.deinit(allocator);
     var dr = dists_payload;
     while (dr.len > 0) {
@@ -288,7 +288,7 @@ pub fn freeFindNode(allocator: std.mem.Allocator, msg: FindNode) void {
 // ---------------------------------------------------------------------------
 
 pub fn encodeNodes(allocator: std.mem.Allocator, msg: Nodes) EncodeError![]u8 {
-    var items = std.ArrayListUnmanaged([]u8){};
+    var items = std.ArrayListUnmanaged([]u8).empty;
     defer {
         for (items.items) |it| allocator.free(it);
         items.deinit(allocator);
@@ -297,7 +297,7 @@ pub fn encodeNodes(allocator: std.mem.Allocator, msg: Nodes) EncodeError![]u8 {
     try appendOwned(&items, allocator, try encodeReqId(allocator, msg.request_id));
     try appendOwned(&items, allocator, try rlpEncodeUint64(allocator, msg.total));
 
-    var enr_items = std.ArrayListUnmanaged([]u8){};
+    var enr_items = std.ArrayListUnmanaged([]u8).empty;
     defer {
         for (enr_items.items) |it| allocator.free(it);
         enr_items.deinit(allocator);
@@ -328,7 +328,7 @@ pub fn decodeNodes(allocator: std.mem.Allocator, data: []const u8) (DecodeError 
     const enrs_item = try rlpDecode(rest);
     const enrs_payload = try enr_mod.rlpListPayload(enrs_item.item);
 
-    var enr_list = std.ArrayListUnmanaged([]const u8){};
+    var enr_list = std.ArrayListUnmanaged([]const u8).empty;
     errdefer {
         for (enr_list.items) |e| allocator.free(e);
         enr_list.deinit(allocator);
@@ -361,7 +361,7 @@ pub fn freeNodes(allocator: std.mem.Allocator, msg: Nodes) void {
 // ---------------------------------------------------------------------------
 
 pub fn encodeTalkReq(allocator: std.mem.Allocator, msg: TalkReq) EncodeError![]u8 {
-    var items = std.ArrayListUnmanaged([]u8){};
+    var items = std.ArrayListUnmanaged([]u8).empty;
     defer {
         for (items.items) |it| allocator.free(it);
         items.deinit(allocator);
@@ -408,7 +408,7 @@ pub fn freeTalkReq(allocator: std.mem.Allocator, msg: TalkReq) void {
 // ---------------------------------------------------------------------------
 
 pub fn encodeTalkRes(allocator: std.mem.Allocator, msg: TalkRes) EncodeError![]u8 {
-    var items = std.ArrayListUnmanaged([]u8){};
+    var items = std.ArrayListUnmanaged([]u8).empty;
     defer {
         for (items.items) |it| allocator.free(it);
         items.deinit(allocator);

--- a/src/discovery/discv5/table.zig
+++ b/src/discovery/discv5/table.zig
@@ -7,6 +7,7 @@
 //! Reference: discv5 spec §5.1 "Node Table".
 
 const std = @import("std");
+const compat = @import("compat");
 const crypto = @import("crypto.zig");
 const standard = @import("../enr/standard.zig");
 
@@ -27,7 +28,7 @@ pub const Entry = struct {
     /// Compressed secp256k1 public key of the remote node.
     pubkey: [crypto.pubkey_len]u8 = [_]u8{0} ** crypto.pubkey_len,
     /// UDP address used for discv5 communication.
-    udp_addr: std.net.Address,
+    udp_addr: compat.Address,
     /// ENR sequence number of the last-seen record.
     enr_seq: u64,
     /// Monotonic timestamp of last successful interaction (ns).
@@ -211,7 +212,7 @@ test "bucket addOrRefresh fills up to k then rejects" {
     for (0..k) |i| {
         const entry = Entry{
             .node_id = makeId(@intCast(i + 1)),
-            .udp_addr = std.net.Address.initIp4(.{ 127, 0, 0, 1 }, 9000),
+            .udp_addr = compat.Address.initIp4(.{ 127, 0, 0, 1 }, 9000),
             .enr_seq = 1,
             .last_seen_ns = 0,
         };
@@ -220,7 +221,7 @@ test "bucket addOrRefresh fills up to k then rejects" {
     try std.testing.expect(bucket.isFull());
     const extra = Entry{
         .node_id = makeId(0xff),
-        .udp_addr = std.net.Address.initIp4(.{ 127, 0, 0, 1 }, 9000),
+        .udp_addr = compat.Address.initIp4(.{ 127, 0, 0, 1 }, 9000),
         .enr_seq = 1,
         .last_seen_ns = 0,
     };
@@ -234,7 +235,7 @@ test "routing table add and closest" {
     for (1..10) |i| {
         try std.testing.expect(table.add(.{
             .node_id = makeId(@intCast(i)),
-            .udp_addr = std.net.Address.initIp4(.{ 127, 0, 0, 1 }, @intCast(9000 + i)),
+            .udp_addr = compat.Address.initIp4(.{ 127, 0, 0, 1 }, @intCast(9000 + i)),
             .enr_seq = 1,
             .last_seen_ns = 0,
         }));
@@ -254,7 +255,7 @@ test "remove decrements total" {
     var table = RoutingTable.init(local);
     _ = table.add(.{
         .node_id = makeId(5),
-        .udp_addr = std.net.Address.initIp4(.{ 127, 0, 0, 1 }, 9005),
+        .udp_addr = compat.Address.initIp4(.{ 127, 0, 0, 1 }, 9005),
         .enr_seq = 1,
         .last_seen_ns = 0,
     });

--- a/src/discovery/enr/enr.zig
+++ b/src/discovery/enr/enr.zig
@@ -236,7 +236,7 @@ pub fn decode(allocator: std.mem.Allocator, raw: []const u8) (EnrError || std.me
     for (seq_bytes) |b| seq = (seq << 8) | b;
 
     // Remaining items: key-value pairs.
-    var pairs = std.ArrayListUnmanaged(KvPair){};
+    var pairs = std.ArrayListUnmanaged(KvPair).empty;
     errdefer {
         for (pairs.items) |*kv| {
             allocator.free(kv.key);
@@ -298,7 +298,7 @@ pub fn rlpEncodeList(allocator: std.mem.Allocator, items: []const []const u8) st
     var payload_len: usize = 0;
     for (items) |it| payload_len += it.len;
 
-    var out = std.ArrayListUnmanaged(u8){};
+    var out = std.ArrayListUnmanaged(u8).empty;
     defer out.deinit(allocator);
 
     if (payload_len <= 55) {
@@ -339,7 +339,7 @@ fn appendOwnedItem(
 pub const EnrBuilder = struct {
     allocator: std.mem.Allocator,
     seq: Seq,
-    pairs: std.ArrayListUnmanaged(KvPair) = .{},
+    pairs: std.ArrayListUnmanaged(KvPair) = .empty,
 
     pub fn init(allocator: std.mem.Allocator, seq: Seq) EnrBuilder {
         return .{ .allocator = allocator, .seq = seq };
@@ -369,7 +369,7 @@ pub const EnrBuilder = struct {
     /// Build the RLP content (without the signature) for signing.
     /// Returns allocated bytes; caller must free.
     pub fn buildContent(self: *const EnrBuilder) std.mem.Allocator.Error![]u8 {
-        var items = std.ArrayListUnmanaged([]u8){};
+        var items = std.ArrayListUnmanaged([]u8).empty;
         defer {
             for (items.items) |it| self.allocator.free(it);
             items.deinit(self.allocator);
@@ -396,7 +396,7 @@ pub const EnrBuilder = struct {
         var sig: [crypto.ecdsa_sig_len]u8 = undefined;
         try crypto.ecdsaSign(&sig, content, privkey);
 
-        var items = std.ArrayListUnmanaged([]u8){};
+        var items = std.ArrayListUnmanaged([]u8).empty;
         defer {
             for (items.items) |it| self.allocator.free(it);
             items.deinit(self.allocator);

--- a/src/discovery/enr/standard.zig
+++ b/src/discovery/enr/standard.zig
@@ -1,6 +1,7 @@
 //! Standard ENR key names and field decoders (EIP-778, devp2p ENR spec).
 
 const std = @import("std");
+const compat = @import("compat");
 const enr = @import("enr.zig");
 
 // ---------------------------------------------------------------------------
@@ -30,9 +31,9 @@ pub const StandardFields = struct {
     /// Compressed secp256k1 public key (33 bytes); null if missing.
     pubkey: ?Secp256k1Pubkey = null,
     /// IPv4 address; null if missing.
-    ip: ?std.net.Ip4Address = null,
+    ip: ?compat.Ip4Address = null,
     /// IPv6 address; null if missing.
-    ip6: ?std.net.Ip6Address = null,
+    ip6: ?compat.Ip6Address = null,
     /// TCP port (host byte order); 0 if missing.
     tcp: u16 = 0,
     /// UDP port (host byte order); 0 if missing.
@@ -52,7 +53,7 @@ pub fn decodeStandard(record: *const enr.Enr) enr.EnrError!StandardFields {
     if (record.get(key_ip)) |raw| {
         const val = try enr.rlpStringValue(raw);
         if (val.len != 4) return error.BadRlp;
-        out.ip = std.net.Ip4Address.init(val[0..4].*, 0);
+        out.ip = compat.Ip4Address.init(val[0..4].*, 0);
     }
 
     if (record.get(key_udp)) |raw| {

--- a/src/discovery/peer_manager.zig
+++ b/src/discovery/peer_manager.zig
@@ -11,6 +11,7 @@
 //! `poll(now_ns, slot_offset_ms)` from the owning event loop.
 
 const std = @import("std");
+const compat = @import("compat");
 const discv5_node = @import("discv5/node.zig");
 const discv5_table = @import("discv5/table.zig");
 const peering_table = @import("peering/table.zig");
@@ -53,7 +54,7 @@ pub const PeerManager = struct {
 
     /// Optional callback invoked after a peer is successfully dialed and registered.
     /// Receives the raw context pointer, the peer's 32-byte NodeId, and the UDP address.
-    on_peer_dialed: ?*const fn (ctx: ?*anyopaque, node_id: [32]u8, addr: std.net.Address) void = null,
+    on_peer_dialed: ?*const fn (ctx: ?*anyopaque, node_id: [32]u8, addr: compat.Address) void = null,
     /// Opaque context pointer forwarded to `on_peer_dialed`.
     on_peer_dialed_ctx: ?*anyopaque = null,
 
@@ -131,8 +132,8 @@ pub const PeerManager = struct {
     // -----------------------------------------------------------------------
 
     /// Issue a QUIC dial and register the peer in the peering table.
-    fn dialPeer(self: *PeerManager, node_id: [32]u8, addr: std.net.Address) void {
-        // Convert std.net.Address to the ListenAddress expected by eth_ec_quic.
+    fn dialPeer(self: *PeerManager, node_id: [32]u8, addr: compat.Address) void {
+        // Convert compat.Address to the ListenAddress expected by eth_ec_quic.
         var host_buf: [64]u8 = undefined;
         const host = addressToHostStr(addr, &host_buf) catch return;
 
@@ -186,20 +187,20 @@ pub const PeerManager = struct {
 };
 
 // ---------------------------------------------------------------------------
-// Helper: convert std.net.Address to a host string
+// Helper: convert compat.Address to a host string
 // ---------------------------------------------------------------------------
 
-fn addressToHostStr(addr: std.net.Address, buf: *[64]u8) ![]const u8 {
+fn addressToHostStr(addr: compat.Address, buf: *[64]u8) ![]const u8 {
     return switch (addr.any.family) {
         std.posix.AF.INET => {
-            const bytes = @as(*const [4]u8, @ptrCast(&addr.in.sa.addr));
+            const bytes = @as(*const [4]u8, @ptrCast(&addr.in.addr));
             return std.fmt.bufPrint(buf, "{}.{}.{}.{}", .{
                 bytes[0], bytes[1], bytes[2], bytes[3],
             });
         },
         std.posix.AF.INET6 => {
             // IPv6 — minimal representation.
-            const bytes = addr.in6.sa.addr;
+            const bytes = addr.in6.addr;
             return std.fmt.bufPrint(buf, "{x:0>2}{x:0>2}:{x:0>2}{x:0>2}:{x:0>2}{x:0>2}:{x:0>2}{x:0>2}:{x:0>2}{x:0>2}:{x:0>2}{x:0>2}:{x:0>2}{x:0>2}:{x:0>2}{x:0>2}", .{
                 bytes[0],  bytes[1],  bytes[2],  bytes[3],
                 bytes[4],  bytes[5],  bytes[6],  bytes[7],
@@ -217,7 +218,7 @@ fn addressToHostStr(addr: std.net.Address, buf: *[64]u8) ![]const u8 {
 
 test "addressToHostStr IPv4" {
     var buf: [64]u8 = undefined;
-    const addr = std.net.Address.initIp4(.{ 192, 168, 1, 1 }, 9000);
+    const addr = compat.Address.initIp4(.{ 192, 168, 1, 1 }, 9000);
     const s = try addressToHostStr(addr, &buf);
     try std.testing.expectEqualStrings("192.168.1.1", s);
 }
@@ -229,13 +230,13 @@ test "evictBelow removes low-scoring peers" {
 
     var good = peering_table.PeerEntry{
         .node_id = [_]u8{1} ** 32,
-        .udp_addr = std.net.Address.initIp4(.{ 127, 0, 0, 1 }, 9000),
+        .udp_addr = compat.Address.initIp4(.{ 127, 0, 0, 1 }, 9000),
     };
     good.score.composite = 100;
 
     var bad = peering_table.PeerEntry{
         .node_id = [_]u8{2} ** 32,
-        .udp_addr = std.net.Address.initIp4(.{ 127, 0, 0, 1 }, 9001),
+        .udp_addr = compat.Address.initIp4(.{ 127, 0, 0, 1 }, 9001),
     };
     bad.score.composite = -150;
 

--- a/src/discovery/peering/table.zig
+++ b/src/discovery/peering/table.zig
@@ -8,6 +8,7 @@
 //! connection pool tier (hot/warm/cold) it currently occupies.
 
 const std = @import("std");
+const compat = @import("compat");
 const score_mod = @import("score.zig");
 const duty_mod = @import("duty.zig");
 const discv5_table = @import("../discv5/table.zig");
@@ -24,7 +25,7 @@ pub const ConnectionTier = enum { hot, warm, cold };
 
 pub const PeerEntry = struct {
     node_id: NodeId,
-    udp_addr: std.net.Address,
+    udp_addr: compat.Address,
     score: Score = .{},
     tier: ConnectionTier = .cold,
     /// Capability field from the peer's ENR.
@@ -38,7 +39,7 @@ pub const PeerEntry = struct {
 // ---------------------------------------------------------------------------
 
 pub const SelfishTable = struct {
-    entries: std.ArrayListUnmanaged(PeerEntry) = .{},
+    entries: std.ArrayListUnmanaged(PeerEntry) = .empty,
     capacity: usize,
 
     pub fn init(capacity: usize) SelfishTable {
@@ -126,7 +127,7 @@ pub const SelfishTable = struct {
 // ---------------------------------------------------------------------------
 
 pub const AltruisticTable = struct {
-    entries: std.ArrayListUnmanaged(PeerEntry) = .{},
+    entries: std.ArrayListUnmanaged(PeerEntry) = .empty,
     capacity: usize,
 
     pub fn init(capacity: usize) AltruisticTable {
@@ -203,7 +204,7 @@ fn makeId(seed: u8) NodeId {
 fn makeEntry(seed: u8, composite: i32) PeerEntry {
     var e = PeerEntry{
         .node_id = makeId(seed),
-        .udp_addr = std.net.Address.initIp4(.{ 127, 0, 0, 1 }, 9000),
+        .udp_addr = compat.Address.initIp4(.{ 127, 0, 0, 1 }, 9000),
     };
     e.score.composite = composite;
     return e;

--- a/src/discovery/peering/warmup.zig
+++ b/src/discovery/peering/warmup.zig
@@ -10,6 +10,7 @@
 //! Reference: ethp2p spec §Peering "session resumption mechanics".
 
 const std = @import("std");
+const compat = @import("compat");
 
 // ---------------------------------------------------------------------------
 // Slot timing constants (12 s slots, 4 phases)
@@ -74,7 +75,7 @@ pub const WarmupRequest = struct {
     /// NodeId of the peer to warm.
     node_id: [32]u8,
     /// UDP address for discv5 / QUIC dial.
-    addr: std.net.Address,
+    addr: compat.Address,
     /// Target slot for which this connection is needed.
     target_slot: u64,
 };
@@ -86,7 +87,7 @@ pub const WarmupRequest = struct {
 pub const Scheduler = struct {
     allocator: std.mem.Allocator,
     /// Queue of outbound warmup requests (FIFO).
-    queue: std.ArrayListUnmanaged(WarmupRequest) = .{},
+    queue: std.ArrayListUnmanaged(WarmupRequest) = .empty,
     /// Current slot number (updated by caller at each slot boundary).
     current_slot: u64 = 0,
 
@@ -161,7 +162,7 @@ test "scheduler accepts request only during idle phase" {
 
     const req = WarmupRequest{
         .node_id = [_]u8{1} ** 32,
-        .addr = std.net.Address.initIp4(.{ 127, 0, 0, 1 }, 9000),
+        .addr = compat.Address.initIp4(.{ 127, 0, 0, 1 }, 9000),
         .target_slot = 1,
     };
 
@@ -182,7 +183,7 @@ test "advanceSlot purges stale requests" {
 
     try sched.queue.append(gpa, .{
         .node_id = [_]u8{1} ** 32,
-        .addr = std.net.Address.initIp4(.{ 127, 0, 0, 1 }, 9000),
+        .addr = compat.Address.initIp4(.{ 127, 0, 0, 1 }, 9000),
         .target_slot = 0,
     });
     sched.advanceSlot(1);

--- a/src/layer/dedup_registry.zig
+++ b/src/layer/dedup_registry.zig
@@ -42,7 +42,7 @@ pub const DedupRegistry = struct {
         message_id: []const u8,
     ) void {
         const prefix = makePrefixLen(channel_id, message_id);
-        var to_remove: std.ArrayListUnmanaged([]const u8) = .{};
+        var to_remove: std.ArrayListUnmanaged([]const u8) = .empty;
         defer to_remove.deinit(allocator);
 
         var it = self.seen.iterator();

--- a/src/layer/emit_planner.zig
+++ b/src/layer/emit_planner.zig
@@ -13,7 +13,7 @@ pub const PlannerError = error{ Empty, OutOfMemory };
 
 pub const EmitPlanner = struct {
     id_to_pos: std.AutoHashMapUnmanaged(usize, usize) = .{},
-    entries: std.ArrayListUnmanaged(EmitEntry) = .{},
+    entries: std.ArrayListUnmanaged(EmitEntry) = .empty,
 
     pub fn init(gpa: std.mem.Allocator) EmitPlanner {
         _ = gpa;

--- a/src/layer/rs_strategy.zig
+++ b/src/layer/rs_strategy.zig
@@ -1,6 +1,7 @@
 //! Unified per-session RS strategy (`broadcast/rs/strategy.go`).
 
 const std = @import("std");
+const compat = @import("compat");
 const bitmap_mod = @import("bitmap.zig");
 const broadcast_types = @import("broadcast_types.zig");
 const emit_planner = @import("emit_planner.zig");
@@ -202,7 +203,7 @@ pub const RsStrategy = struct {
         const tot = preamble.totalChunks();
 
         var seed: u64 = undefined;
-        std.crypto.random.bytes(std.mem.asBytes(&seed));
+        compat.random.bytes(std.mem.asBytes(&seed));
 
         const chunks = try allocator.alloc([]u8, tot);
         errdefer allocator.free(chunks);
@@ -420,10 +421,10 @@ pub const RsStrategy = struct {
 
     pub fn pollChunks(self: *RsStrategy) (Allocator.Error || emit_planner.PlannerError)![]broadcast_types.ChunkDispatch(ChunkIdent) {
         const allocator = self.allocator;
-        var list: std.ArrayListUnmanaged(broadcast_types.ChunkDispatch(ChunkIdent)) = .{};
+        var list: std.ArrayListUnmanaged(broadcast_types.ChunkDispatch(ChunkIdent)) = .empty;
         errdefer list.deinit(allocator);
 
-        var order: std.ArrayListUnmanaged(PollPeer) = .{};
+        var order: std.ArrayListUnmanaged(PollPeer) = .empty;
         defer order.deinit(allocator);
 
         var it = self.peers.iterator();
@@ -444,7 +445,7 @@ pub const RsStrategy = struct {
 
     fn allocate(self: *RsStrategy, peer: []const u8, ps: *PeerState) (Allocator.Error || emit_planner.PlannerError)!?broadcast_types.ChunkDispatch(ChunkIdent) {
         const allocator = self.allocator;
-        var skipped: std.ArrayListUnmanaged(emit_planner.EmitEntry) = .{};
+        var skipped: std.ArrayListUnmanaged(emit_planner.EmitEntry) = .empty;
         defer skipped.deinit(allocator);
 
         var found_idx: ?usize = null;

--- a/src/layer/verify_queue.zig
+++ b/src/layer/verify_queue.zig
@@ -11,7 +11,7 @@ pub const VerifyRecord = struct {
 };
 
 pub const VerifyQueue = struct {
-    items: std.ArrayListUnmanaged(VerifyRecord) = .{},
+    items: std.ArrayListUnmanaged(VerifyRecord) = .empty,
 
     pub fn deinit(self: *VerifyQueue, allocator: Allocator) void {
         self.items.deinit(allocator);

--- a/src/layer/verify_workers.zig
+++ b/src/layer/verify_workers.zig
@@ -4,6 +4,7 @@
 //! allocator (for example `page_allocator` or a locked GPA), not `std.testing.allocator`.
 
 const std = @import("std");
+const compat = @import("compat");
 const broadcast_types = @import("broadcast_types.zig");
 const verify_queue_mod = @import("verify_queue.zig");
 
@@ -20,12 +21,12 @@ pub const VerifyWorkerPool = struct {
     allocator: Allocator,
     /// Allocator for `out.push` growth; must match whoever calls `VerifyQueue.deinit`.
     queue_allocator: Allocator,
-    pool: std.Thread.Pool,
+    pool: compat.Pool,
     out: *verify_queue_mod.VerifyQueue,
-    out_mutex: std.Thread.Mutex = .{},
+    out_mutex: compat.Mutex = .{},
 
     /// Initializes `self` in place. Worker threads capture `&self.pool`; the `Thread.Pool` must not be
-    /// stack-copied after `init` (see `std.Thread.Pool.init`).
+    /// stack-copied after `init` (see `compat.Pool.init`).
     pub fn init(
         self: *VerifyWorkerPool,
         pool_allocator: Allocator,
@@ -54,7 +55,7 @@ pub const VerifyWorkerPool = struct {
     }
 
     /// Same as `schedule`, but increments `wg` before enqueue and finishes after the result is pushed.
-    pub fn scheduleWait(self: *VerifyWorkerPool, wg: *std.Thread.WaitGroup, job: VerifyJob) !void {
+    pub fn scheduleWait(self: *VerifyWorkerPool, wg: *compat.WaitGroup, job: VerifyJob) !void {
         const owned = try self.allocator.dupe(u8, job.data);
         errdefer self.allocator.free(owned);
         self.pool.spawnWg(wg, runOne, .{ self, job.handle, job.expected_hash, owned });

--- a/src/sim/gossipsub_broadcast.zig
+++ b/src/sim/gossipsub_broadcast.zig
@@ -33,7 +33,7 @@ test "encodeAndFanout roundtrip through mesh" {
     const app = [_]u8{ 1, 2, 3, 4 };
     try encodeAndFanout(&mesh, gpa, "alice", topic, "mid-z", &app);
 
-    var bob_inbox: std.ArrayListUnmanaged([]u8) = .{};
+    var bob_inbox: std.ArrayListUnmanaged([]u8) = .empty;
     defer {
         for (bob_inbox.items) |s| gpa.free(s);
         bob_inbox.deinit(gpa);

--- a/src/sim/gossipsub_interop.zig
+++ b/src/sim/gossipsub_interop.zig
@@ -38,7 +38,7 @@ test "mesh fanout two recipients decode same application payload" {
 
     const names = [_][]const u8{ "bob", "carol" };
     for (names) |who| {
-        var inbox: std.ArrayListUnmanaged([]u8) = .{};
+        var inbox: std.ArrayListUnmanaged([]u8) = .empty;
         defer {
             for (inbox.items) |s| gpa.free(s);
             inbox.deinit(gpa);

--- a/src/sim/gossipsub_protocol.zig
+++ b/src/sim/gossipsub_protocol.zig
@@ -48,7 +48,7 @@ pub const FanoutMesh = struct {
         const t_gop = try self.subscriptions.getOrPut(self.allocator, topic);
         if (!t_gop.found_existing) {
             t_gop.key_ptr.* = try self.allocator.dupe(u8, topic);
-            t_gop.value_ptr.* = .{};
+            t_gop.value_ptr.* = .empty;
         }
 
         for (t_gop.value_ptr.items) |p| {
@@ -71,7 +71,7 @@ pub const FanoutMesh = struct {
             const i_gop = try self.inboxes.getOrPut(self.allocator, peer);
             if (!i_gop.found_existing) {
                 i_gop.key_ptr.* = try self.allocator.dupe(u8, peer);
-                i_gop.value_ptr.* = .{};
+                i_gop.value_ptr.* = .empty;
             }
             try i_gop.value_ptr.append(self.allocator, blob);
         }
@@ -98,7 +98,7 @@ test "fanout delivers to subscribers except publisher" {
 
     try mesh.publishData("alice", topic, "hello");
 
-    var bob_inbox: std.ArrayListUnmanaged([]u8) = .{};
+    var bob_inbox: std.ArrayListUnmanaged([]u8) = .empty;
     defer {
         for (bob_inbox.items) |s| gpa.free(s);
         bob_inbox.deinit(gpa);
@@ -107,7 +107,7 @@ test "fanout delivers to subscribers except publisher" {
     try std.testing.expectEqual(@as(usize, 1), bob_inbox.items.len);
     try std.testing.expectEqualStrings("hello", bob_inbox.items[0]);
 
-    var alice_inbox: std.ArrayListUnmanaged([]u8) = .{};
+    var alice_inbox: std.ArrayListUnmanaged([]u8) = .empty;
     defer alice_inbox.deinit(gpa);
     try mesh.drainPeer("alice", &alice_inbox);
     try std.testing.expectEqual(@as(usize, 0), alice_inbox.items.len);

--- a/src/sim/gossipsub_rpc_host.zig
+++ b/src/sim/gossipsub_rpc_host.zig
@@ -16,7 +16,7 @@ pub const Link = struct {
     gpa: Allocator,
 
     pub fn init(gpa: Allocator) Link {
-        return .{ .ab = .{}, .ba = .{}, .gpa = gpa };
+        return .{ .ab = .empty, .ba = .empty, .gpa = gpa };
     }
 
     pub fn deinit(self: *Link) void {

--- a/src/sim/gossipsub_rpc_pb.zig
+++ b/src/sim/gossipsub_rpc_pb.zig
@@ -101,7 +101,7 @@ fn appendTagLenBytes(list: *std.ArrayListUnmanaged(u8), allocator: Allocator, fi
 
 /// Serializes `ControlIHave` (message body only, not wrapped in `ControlMessage`).
 pub fn encodeIHave(allocator: Allocator, topic: ?[]const u8, message_ids: []const []const u8) Allocator.Error![]u8 {
-    var list: std.ArrayListUnmanaged(u8) = .{};
+    var list: std.ArrayListUnmanaged(u8) = .empty;
     errdefer list.deinit(allocator);
     if (topic) |t| {
         try appendTagLenBytes(&list, allocator, 1, t);
@@ -114,7 +114,7 @@ pub fn encodeIHave(allocator: Allocator, topic: ?[]const u8, message_ids: []cons
 
 /// Serializes `ControlIWant` (message body only).
 pub fn encodeIWant(allocator: Allocator, message_ids: []const []const u8) Allocator.Error![]u8 {
-    var list: std.ArrayListUnmanaged(u8) = .{};
+    var list: std.ArrayListUnmanaged(u8) = .empty;
     errdefer list.deinit(allocator);
     for (message_ids) |mid| {
         try appendTagLenBytes(&list, allocator, 1, mid);
@@ -124,7 +124,7 @@ pub fn encodeIWant(allocator: Allocator, message_ids: []const []const u8) Alloca
 
 /// Top-level `RPC` with only `control` set (field 3). `control_body` is a serialized `ControlMessage`.
 pub fn encodeRpcEnvelopeControl(allocator: Allocator, control_body: []const u8) Allocator.Error![]u8 {
-    var list: std.ArrayListUnmanaged(u8) = .{};
+    var list: std.ArrayListUnmanaged(u8) = .empty;
     errdefer list.deinit(allocator);
     try appendTagLenBytes(&list, allocator, 3, control_body);
     return try list.toOwnedSlice(allocator);
@@ -141,7 +141,7 @@ pub fn decodeRpcControlOnly(buf: []const u8) DecodeError![]const u8 {
 
 /// Wraps one `encodeIHave` payload as `ControlMessage.ihave` (field 1, repeated).
 pub fn encodeControlMessageSingleIHave(allocator: Allocator, ihave_body: []const u8) Allocator.Error![]u8 {
-    var list: std.ArrayListUnmanaged(u8) = .{};
+    var list: std.ArrayListUnmanaged(u8) = .empty;
     errdefer list.deinit(allocator);
     try appendTagLenBytes(&list, allocator, 1, ihave_body);
     return try list.toOwnedSlice(allocator);
@@ -163,7 +163,7 @@ fn decodeTagLen(buf: []const u8, offset: *usize) DecodeError!struct { field: u32
 pub fn decodeIHaveOwned(allocator: Allocator, buf: []const u8) (DecodeError || Allocator.Error)!IHaveOwned {
     var offset: usize = 0;
     var topic: ?[]u8 = null;
-    var ids: std.ArrayListUnmanaged([]u8) = .{};
+    var ids: std.ArrayListUnmanaged([]u8) = .empty;
     errdefer {
         if (topic) |t| allocator.free(t);
         for (ids.items) |m| allocator.free(m);
@@ -194,7 +194,7 @@ pub fn decodeIHaveOwned(allocator: Allocator, buf: []const u8) (DecodeError || A
 
 pub fn decodeIWantOwned(allocator: Allocator, buf: []const u8) (DecodeError || Allocator.Error)!IWantOwned {
     var offset: usize = 0;
-    var ids: std.ArrayListUnmanaged([]u8) = .{};
+    var ids: std.ArrayListUnmanaged([]u8) = .empty;
     errdefer {
         for (ids.items) |m| allocator.free(m);
         ids.deinit(allocator);
@@ -233,7 +233,7 @@ pub const SubOptsOwned = struct {
 };
 
 pub fn encodeSubOpts(allocator: Allocator, s: SubOptsRef) Allocator.Error![]u8 {
-    var list: std.ArrayListUnmanaged(u8) = .{};
+    var list: std.ArrayListUnmanaged(u8) = .empty;
     errdefer list.deinit(allocator);
     if (s.subscribe) |b| try appendTagVarintField(&list, allocator, 1, if (b) 1 else 0);
     if (s.topicid) |t| try appendTagLenBytes(&list, allocator, 2, t);
@@ -314,7 +314,7 @@ pub const GossipMessageOwned = struct {
 };
 
 pub fn encodeGossipMessage(allocator: Allocator, m: GossipMessageRef) Allocator.Error![]u8 {
-    var list: std.ArrayListUnmanaged(u8) = .{};
+    var list: std.ArrayListUnmanaged(u8) = .empty;
     errdefer list.deinit(allocator);
     if (m.from) |x| try appendTagLenBytes(&list, allocator, 1, x);
     if (m.data) |x| try appendTagLenBytes(&list, allocator, 2, x);
@@ -384,7 +384,7 @@ pub const PeerInfoOwned = struct {
 };
 
 pub fn encodePeerInfo(allocator: Allocator, p: PeerInfoRef) Allocator.Error![]u8 {
-    var list: std.ArrayListUnmanaged(u8) = .{};
+    var list: std.ArrayListUnmanaged(u8) = .empty;
     errdefer list.deinit(allocator);
     if (p.peer_id) |x| try appendTagLenBytes(&list, allocator, 1, x);
     if (p.signed_peer_record) |x| try appendTagLenBytes(&list, allocator, 2, x);
@@ -431,7 +431,7 @@ pub const ControlGraftOwned = struct {
 };
 
 pub fn encodeControlGraft(allocator: Allocator, g: ControlGraftRef) Allocator.Error![]u8 {
-    var list: std.ArrayListUnmanaged(u8) = .{};
+    var list: std.ArrayListUnmanaged(u8) = .empty;
     errdefer list.deinit(allocator);
     if (g.topic) |t| try appendTagLenBytes(&list, allocator, 1, t);
     return try list.toOwnedSlice(allocator);
@@ -478,7 +478,7 @@ pub const ControlPruneOwned = struct {
 };
 
 pub fn encodeControlPrune(allocator: Allocator, p: ControlPruneRef) Allocator.Error![]u8 {
-    var list: std.ArrayListUnmanaged(u8) = .{};
+    var list: std.ArrayListUnmanaged(u8) = .empty;
     errdefer list.deinit(allocator);
     if (p.topic) |t| try appendTagLenBytes(&list, allocator, 1, t);
     for (p.peers) |peer| {
@@ -493,7 +493,7 @@ pub fn encodeControlPrune(allocator: Allocator, p: ControlPruneRef) Allocator.Er
 pub fn decodeControlPruneOwned(allocator: Allocator, buf: []const u8) (DecodeError || Allocator.Error)!ControlPruneOwned {
     var offset: usize = 0;
     var topic: ?[]u8 = null;
-    var peer_list: std.ArrayListUnmanaged(PeerInfoOwned) = .{};
+    var peer_list: std.ArrayListUnmanaged(PeerInfoOwned) = .empty;
     errdefer {
         if (topic) |t| allocator.free(t);
         for (peer_list.items) |*x| x.deinit(allocator);
@@ -548,7 +548,7 @@ pub const ControlMessageEncodeRef = struct {
 };
 
 pub fn encodeControlMessage(allocator: Allocator, m: ControlMessageEncodeRef) Allocator.Error![]u8 {
-    var list: std.ArrayListUnmanaged(u8) = .{};
+    var list: std.ArrayListUnmanaged(u8) = .empty;
     errdefer list.deinit(allocator);
     for (m.ihave) |b| try appendTagLenBytes(&list, allocator, 1, b);
     for (m.iwant) |b| try appendTagLenBytes(&list, allocator, 2, b);
@@ -581,27 +581,27 @@ pub const ControlMessageOwned = struct {
 };
 
 pub fn decodeControlMessageOwned(allocator: Allocator, buf: []const u8) (DecodeError || Allocator.Error)!ControlMessageOwned {
-    var ihave: std.ArrayListUnmanaged([]u8) = .{};
+    var ihave: std.ArrayListUnmanaged([]u8) = .empty;
     errdefer {
         for (ihave.items) |x| allocator.free(x);
         ihave.deinit(allocator);
     }
-    var iwant: std.ArrayListUnmanaged([]u8) = .{};
+    var iwant: std.ArrayListUnmanaged([]u8) = .empty;
     errdefer {
         for (iwant.items) |x| allocator.free(x);
         iwant.deinit(allocator);
     }
-    var graft: std.ArrayListUnmanaged([]u8) = .{};
+    var graft: std.ArrayListUnmanaged([]u8) = .empty;
     errdefer {
         for (graft.items) |x| allocator.free(x);
         graft.deinit(allocator);
     }
-    var prune: std.ArrayListUnmanaged([]u8) = .{};
+    var prune: std.ArrayListUnmanaged([]u8) = .empty;
     errdefer {
         for (prune.items) |x| allocator.free(x);
         prune.deinit(allocator);
     }
-    var idontwant: std.ArrayListUnmanaged([]u8) = .{};
+    var idontwant: std.ArrayListUnmanaged([]u8) = .empty;
     errdefer {
         for (idontwant.items) |x| allocator.free(x);
         idontwant.deinit(allocator);
@@ -660,7 +660,7 @@ pub const PartialMessagesExtensionOwned = struct {
 };
 
 pub fn encodePartialMessagesExtension(allocator: Allocator, p: PartialMessagesExtensionRef) Allocator.Error![]u8 {
-    var list: std.ArrayListUnmanaged(u8) = .{};
+    var list: std.ArrayListUnmanaged(u8) = .empty;
     errdefer list.deinit(allocator);
     if (p.topic_id) |x| try appendTagLenBytes(&list, allocator, 1, x);
     if (p.group_id) |x| try appendTagLenBytes(&list, allocator, 2, x);
@@ -729,7 +729,7 @@ pub const RpcOwned = struct {
 };
 
 pub fn encodeRpc(allocator: Allocator, r: RpcEncodeRef) Allocator.Error![]u8 {
-    var list: std.ArrayListUnmanaged(u8) = .{};
+    var list: std.ArrayListUnmanaged(u8) = .empty;
     errdefer list.deinit(allocator);
     for (r.subscriptions) |s| {
         const inner = try encodeSubOpts(allocator, s);
@@ -752,12 +752,12 @@ pub fn encodeRpc(allocator: Allocator, r: RpcEncodeRef) Allocator.Error![]u8 {
 
 pub fn decodeRpcOwned(allocator: Allocator, buf: []const u8) (DecodeError || Allocator.Error)!RpcOwned {
     var offset: usize = 0;
-    var subs: std.ArrayListUnmanaged(SubOptsOwned) = .{};
+    var subs: std.ArrayListUnmanaged(SubOptsOwned) = .empty;
     errdefer {
         for (subs.items) |*s| s.deinit(allocator);
         subs.deinit(allocator);
     }
-    var pubs: std.ArrayListUnmanaged(GossipMessageOwned) = .{};
+    var pubs: std.ArrayListUnmanaged(GossipMessageOwned) = .empty;
     errdefer {
         for (pubs.items) |*m| m.deinit(allocator);
         pubs.deinit(allocator);
@@ -812,7 +812,7 @@ pub fn decodeRpcOwned(allocator: Allocator, buf: []const u8) (DecodeError || All
 
 /// Prefixes `rpc_body` with an unsigned protobuf varint of its length (common libp2p stream framing).
 pub fn encodeRpcLengthPrefixed(allocator: Allocator, rpc_body: []const u8) Allocator.Error![]u8 {
-    var list: std.ArrayListUnmanaged(u8) = .{};
+    var list: std.ArrayListUnmanaged(u8) = .empty;
     errdefer list.deinit(allocator);
     try appendVarintUnmanaged(&list, allocator, @intCast(rpc_body.len));
     try list.appendSlice(allocator, rpc_body);

--- a/src/sim/rs_mesh.zig
+++ b/src/sim/rs_mesh.zig
@@ -11,6 +11,7 @@
 //! `RsStrategy.chunkSent(..., false)` so inflight state matches a failed send.
 
 const std = @import("std");
+const compat = @import("compat");
 const broadcast_types = @import("../layer/broadcast_types.zig");
 const rs_init = @import("../layer/rs_init.zig");
 const rs_strategy = @import("../layer/rs_strategy.zig");
@@ -393,7 +394,7 @@ test "abstract RS mesh six nodes env stress (ZIG_ETHP2P_STRESS=1)" {
     if (builtin.os.tag == .windows) return;
 
     const gpa = std.testing.allocator;
-    const env = std.process.getEnvVarOwned(gpa, "ZIG_ETHP2P_STRESS") catch return;
+    const env = compat.getEnvVarOwned(gpa, "ZIG_ETHP2P_STRESS") catch return;
     defer gpa.free(env);
     if (!std.mem.eql(u8, env, "1")) return;
     var payload: [10 * 1024]u8 = undefined;
@@ -414,7 +415,7 @@ test "abstract RS mesh eight nodes ring env stress (large-network scale)" {
     if (builtin.os.tag == .windows) return;
 
     const gpa = std.testing.allocator;
-    const env = std.process.getEnvVarOwned(gpa, "ZIG_ETHP2P_STRESS") catch return;
+    const env = compat.getEnvVarOwned(gpa, "ZIG_ETHP2P_STRESS") catch return;
     defer gpa.free(env);
     if (!std.mem.eql(u8, env, "1")) return;
 
@@ -444,7 +445,7 @@ test "abstract RS mesh sixteen nodes ring env stress" {
     if (builtin.os.tag == .windows) return;
 
     const gpa = std.testing.allocator;
-    const env = std.process.getEnvVarOwned(gpa, "ZIG_ETHP2P_STRESS") catch return;
+    const env = compat.getEnvVarOwned(gpa, "ZIG_ETHP2P_STRESS") catch return;
     defer gpa.free(env);
     if (!std.mem.eql(u8, env, "1")) return;
 

--- a/src/transport/eth_ec_quic.zig
+++ b/src/transport/eth_ec_quic.zig
@@ -4,6 +4,7 @@
 //! Run `zig build test-quic` for handshake + BCAST/SESS stream smoke tests.
 
 const std = @import("std");
+const compat = @import("compat");
 const builtin = @import("builtin");
 const common = @import("eth_ec_quic_common.zig");
 const quic = @import("quic");
@@ -58,7 +59,7 @@ pub fn dial(allocator: *std.mem.Allocator, config: EthEcQuicConfig, remote: List
 pub fn listenOnFd(
     allocator: *std.mem.Allocator,
     fd: std.posix.fd_t,
-    local_addr: std.net.Address,
+    local_addr: compat.Address,
     config: EthEcQuicConfig,
 ) !EthEcQuicListener {
     const enabled = @import("eth_ec_quic_enabled.zig");
@@ -77,8 +78,8 @@ pub fn pollListener(listener: *EthEcQuicListener, timeout_ms: u32) !void {
 pub fn feedPacket(
     listener: *EthEcQuicListener,
     data: []const u8,
-    peer: std.net.Address,
-    local: std.net.Address,
+    peer: compat.Address,
+    local: compat.Address,
 ) void {
     quic.feedPacket(listener.ep, data, peer, local);
 }
@@ -104,11 +105,11 @@ test "UDP bind ephemeral (bootstrap for future QUIC socket)" {
     if (builtin.os.tag == .windows) return error.SkipZigTest;
     if (builtin.os.tag == .wasi) return error.SkipZigTest;
 
-    const sock = try std.posix.socket(std.posix.AF.INET, std.posix.SOCK.DGRAM, std.posix.IPPROTO.UDP);
-    defer std.posix.close(sock);
+    const sock = try compat.socket(std.posix.AF.INET, std.posix.SOCK.DGRAM, std.posix.IPPROTO.UDP);
+    defer compat.close(sock);
 
-    const any = try std.net.Address.parseIp("127.0.0.1", 0);
-    try std.posix.bind(sock, &any.any, any.getOsSockLen());
+    const any = try compat.Address.parseIp("127.0.0.1", 0);
+    try compat.bind(sock, &any.any, any.getOsSockLen());
 }
 
 test {

--- a/src/transport/eth_ec_quic_enabled.zig
+++ b/src/transport/eth_ec_quic_enabled.zig
@@ -1,6 +1,7 @@
 //! QUIC + TLS implementation (`src/transport/zquic_quic_shim.zig` + [zquic](https://github.com/ch4r10t33r/zquic)).
 
 const std = @import("std");
+const compat = @import("compat");
 const quic = @import("quic");
 const common = @import("eth_ec_quic_common.zig");
 const test_certs = @import("eth_ec_quic_test_certs.zig");
@@ -106,7 +107,7 @@ pub fn listenImpl(
 pub fn listenImplFromFd(
     allocator: *std.mem.Allocator,
     fd: std.posix.fd_t,
-    local_addr: std.net.Address,
+    local_addr: compat.Address,
     config: common.EthEcQuicConfig,
 ) !*quic.QuicEndpoint {
     if (config.server_certificate_pem_path == null or config.server_private_key_pem_path == null) {
@@ -155,7 +156,7 @@ test "QUIC listen + dial, TLS handshake, ALPN eth-ec-broadcast" {
     if (@import("builtin").os.tag == .windows) return error.SkipZigTest;
     if (@import("builtin").os.tag == .wasi) return error.SkipZigTest;
 
-    var gpa = std.heap.GeneralPurposeAllocator(.{}){};
+    var gpa = std.heap.DebugAllocator(.{}){};
     defer _ = gpa.deinit();
     var alloc = gpa.allocator();
 
@@ -238,7 +239,7 @@ test "QUIC UNI streams: symmetric BCAST handshake + SESS session_open (wire fram
     if (@import("builtin").os.tag == .windows) return error.SkipZigTest;
     if (@import("builtin").os.tag == .wasi) return error.SkipZigTest;
 
-    var gpa = std.heap.GeneralPurposeAllocator(.{}){};
+    var gpa = std.heap.DebugAllocator(.{}){};
     defer _ = gpa.deinit();
     var alloc = gpa.allocator();
 
@@ -304,47 +305,45 @@ test "QUIC UNI streams: symmetric BCAST handshake + SESS session_open (wire fram
     const cli_bcast_out = try quic.streamMakeUni(conn, srv);
     const srv_bcast_out = try quic.streamMakeUni(sc, client_ep);
 
-    var cli_bcast_payload = std.ArrayList(u8).empty;
-    defer cli_bcast_payload.deinit(alloc);
+    var cli_bcast_payload = std.Io.Writer.Allocating.init(alloc);
+    defer cli_bcast_payload.deinit();
     {
-        const w = cli_bcast_payload.writer(alloc);
-        try bcast_stream.writeBcastHandshakeOpen(w, alloc, .{
+        try bcast_stream.writeBcastHandshakeOpen(&cli_bcast_payload.writer, alloc, .{
             .version = 1,
             .channels = &.{ "blocks", "atts" },
             .peer_id = "client-peer",
         });
     }
-    try quic.streamQueueWrite(cli_bcast_out, cli_bcast_payload.items);
+    try quic.streamQueueWrite(cli_bcast_out, cli_bcast_payload.written());
     try quic.streamDrainWrites(cli_bcast_out, srv, 10_000);
 
-    var srv_bcast_payload = std.ArrayList(u8).empty;
-    defer srv_bcast_payload.deinit(alloc);
+    var srv_bcast_payload = std.Io.Writer.Allocating.init(alloc);
+    defer srv_bcast_payload.deinit();
     {
-        const w = srv_bcast_payload.writer(alloc);
-        try bcast_stream.writeBcastHandshakeOpen(w, alloc, .{
+        try bcast_stream.writeBcastHandshakeOpen(&srv_bcast_payload.writer, alloc, .{
             .version = 1,
             .channels = &.{"chunks"},
             .peer_id = "server-peer",
         });
     }
-    try quic.streamQueueWrite(srv_bcast_out, srv_bcast_payload.items);
+    try quic.streamQueueWrite(srv_bcast_out, srv_bcast_payload.written());
     try quic.streamDrainWrites(srv_bcast_out, client_ep, 10_000);
 
     // Accept the peer's inbound BCAST UNI stream on each side.
     const srv_bcast_in = try acceptIncomingQuicUniStream(sc, srv, client_ep);
     const cli_bcast_in = try acceptIncomingQuicUniStream(conn, client_ep, srv);
 
-    try waitQuicStreamBytes(srv_bcast_in, srv, client_ep, cli_bcast_payload.items.len, 10_000);
-    try waitQuicStreamBytes(cli_bcast_in, client_ep, srv, srv_bcast_payload.items.len, 10_000);
+    try waitQuicStreamBytes(srv_bcast_in, srv, client_ep, cli_bcast_payload.written().len, 10_000);
+    try waitQuicStreamBytes(cli_bcast_in, client_ep, srv, srv_bcast_payload.written().len, 10_000);
 
-    try std.testing.expectEqualSlices(u8, cli_bcast_payload.items, quic.streamReadSlice(srv_bcast_in));
-    try std.testing.expectEqualSlices(u8, srv_bcast_payload.items, quic.streamReadSlice(cli_bcast_in));
+    try std.testing.expectEqualSlices(u8, cli_bcast_payload.written(), quic.streamReadSlice(srv_bcast_in));
+    try std.testing.expectEqualSlices(u8, srv_bcast_payload.written(), quic.streamReadSlice(cli_bcast_in));
 
     // Decode the client's BCAST handshake as seen by the server.
     const bcast_copy = try alloc.dupe(u8, quic.streamReadSlice(srv_bcast_in));
     defer alloc.free(bcast_copy);
-    var bcast_fbs = std.io.fixedBufferStream(bcast_copy);
-    var hs_owned = try bcast_stream.readBcastPeerHandshake(alloc, bcast_fbs.reader());
+    var bcast_fbs = std.Io.Reader.fixed(bcast_copy);
+    var hs_owned = try bcast_stream.readBcastPeerHandshake(alloc, &bcast_fbs);
     defer hs_owned.deinit(alloc);
     switch (hs_owned) {
         .peer_handshake => |h| {
@@ -357,30 +356,29 @@ test "QUIC UNI streams: symmetric BCAST handshake + SESS session_open (wire fram
     // --- SESS UNI stream (peer_ctrl.go handleSessionOpen) ---
     // Client opens a SESS UNI stream and writes session_open.
     const cli_sess = try quic.streamMakeUni(conn, srv);
-    var sess_payload = std.ArrayList(u8).empty;
-    defer sess_payload.deinit(alloc);
+    var sess_payload = std.Io.Writer.Allocating.init(alloc);
+    defer sess_payload.deinit();
     {
-        const w = sess_payload.writer(alloc);
-        try sess_stream.writeSessSessionOpen(w, alloc, .{
+        try sess_stream.writeSessSessionOpen(&sess_payload.writer, alloc, .{
             .channel = "ch1",
             .message_id = "mid",
             .preamble = &.{ 1, 2, 3 },
             .initial_update = &.{ 4, 5 },
         });
     }
-    try quic.streamQueueWrite(cli_sess, sess_payload.items);
+    try quic.streamQueueWrite(cli_sess, sess_payload.written());
     try quic.streamDrainWrites(cli_sess, srv, 10_000);
 
     // Server accepts the SESS UNI stream (peer_in.go runAcceptLoop).
     const srv_sess = try acceptIncomingQuicUniStream(sc, srv, client_ep);
-    try waitQuicStreamBytes(srv_sess, srv, client_ep, sess_payload.items.len, 10_000);
-    try std.testing.expectEqualSlices(u8, sess_payload.items, quic.streamReadSlice(srv_sess));
+    try waitQuicStreamBytes(srv_sess, srv, client_ep, sess_payload.written().len, 10_000);
+    try std.testing.expectEqualSlices(u8, sess_payload.written(), quic.streamReadSlice(srv_sess));
 
     // Decode SESS session_open frame.
     const sess_copy = try alloc.dupe(u8, quic.streamReadSlice(srv_sess));
     defer alloc.free(sess_copy);
-    var sess_fbs = std.io.fixedBufferStream(sess_copy);
-    const sess_r = sess_fbs.reader();
+    var sess_fbs = std.Io.Reader.fixed(sess_copy);
+    const sess_r = &sess_fbs;
     const sel = try protocol.readSelectorByte(sess_r);
     try std.testing.expectEqual(protocol.Protocol.sess, sel);
     var open_owned = try sess_stream.readSessSessionOpenAfterSelector(alloc, sess_r);
@@ -402,7 +400,7 @@ test "QUIC EngineQuicHost SESS session_open + CHUNK relay ingest" {
     if (@import("builtin").os.tag == .windows) return error.SkipZigTest;
     if (@import("builtin").os.tag == .wasi) return error.SkipZigTest;
 
-    var gpa = std.heap.GeneralPurposeAllocator(.{}){};
+    var gpa = std.heap.DebugAllocator(.{}){};
     defer _ = gpa.deinit();
     var alloc = gpa.allocator();
 
@@ -494,30 +492,28 @@ test "QUIC EngineQuicHost SESS session_open + CHUNK relay ingest" {
         .peer_id = "client-peer",
     });
 
-    var srv_bcast_payload = std.ArrayList(u8).empty;
-    defer srv_bcast_payload.deinit(alloc);
+    var srv_bcast_payload = std.Io.Writer.Allocating.init(alloc);
+    defer srv_bcast_payload.deinit();
     {
-        const w = srv_bcast_payload.writer(alloc);
-        try bcast_stream.writeBcastHandshakeOpen(w, alloc, .{
+        try bcast_stream.writeBcastHandshakeOpen(&srv_bcast_payload.writer, alloc, .{
             .version = 1,
             .channels = &.{"ch1"},
             .peer_id = "server-peer",
         });
     }
-    try quic.streamQueueWrite(host.peer.bcast_out.?, srv_bcast_payload.items);
+    try quic.streamQueueWrite(host.peer.bcast_out.?, srv_bcast_payload.written());
     try quic.streamDrainWrites(host.peer.bcast_out.?, client_ep, 10_000);
 
-    var cli_bcast_payload = std.ArrayList(u8).empty;
-    defer cli_bcast_payload.deinit(alloc);
+    var cli_bcast_payload = std.Io.Writer.Allocating.init(alloc);
+    defer cli_bcast_payload.deinit();
     {
-        const w = cli_bcast_payload.writer(alloc);
-        try bcast_stream.writeBcastHandshakeOpen(w, alloc, .{
+        try bcast_stream.writeBcastHandshakeOpen(&cli_bcast_payload.writer, alloc, .{
             .version = 1,
             .channels = &.{"ch1"},
             .peer_id = "client-peer",
         });
     }
-    try quic.streamQueueWrite(cli_pc.bcast_out.?, cli_bcast_payload.items);
+    try quic.streamQueueWrite(cli_pc.bcast_out.?, cli_bcast_payload.written());
     try quic.streamDrainWrites(cli_pc.bcast_out.?, srv, 10_000);
 
     rounds = 0;
@@ -553,18 +549,17 @@ test "QUIC EngineQuicHost SESS session_open + CHUNK relay ingest" {
     defer alloc.free(pre_bytes);
 
     const cli_sess = try quic.streamMakeUni(conn, srv);
-    var sess_pl = std.ArrayList(u8).empty;
-    defer sess_pl.deinit(alloc);
+    var sess_pl = std.Io.Writer.Allocating.init(alloc);
+    defer sess_pl.deinit();
     {
-        const w = sess_pl.writer(alloc);
-        try sess_stream.writeSessSessionOpen(w, alloc, .{
+        try sess_stream.writeSessSessionOpen(&sess_pl.writer, alloc, .{
             .channel = "ch1",
             .message_id = "m1",
             .preamble = pre_bytes,
             .initial_update = &.{},
         });
     }
-    try quic.streamQueueWrite(cli_sess, sess_pl.items);
+    try quic.streamQueueWrite(cli_sess, sess_pl.written());
     try quic.streamDrainWrites(cli_sess, srv, 10_000);
 
     rounds = 0;
@@ -577,13 +572,12 @@ test "QUIC EngineQuicHost SESS session_open + CHUNK relay ingest" {
     try std.testing.expect(ch.sessionStrategy("m1") != null);
 
     const cli_chunk = try quic.streamMakeUni(conn, srv);
-    var chunk_pl = std.ArrayList(u8).empty;
-    defer chunk_pl.deinit(alloc);
+    var chunk_pl = std.Io.Writer.Allocating.init(alloc);
+    defer chunk_pl.deinit();
     {
-        const w = chunk_pl.writer(alloc);
-        try chunk_stream.writeRsShardChunk(w, alloc, "ch1", "m1", 0, origin.chunks[0]);
+        try chunk_stream.writeRsShardChunk(&chunk_pl.writer, alloc, "ch1", "m1", 0, origin.chunks[0]);
     }
-    try quic.streamQueueWrite(cli_chunk, chunk_pl.items);
+    try quic.streamQueueWrite(cli_chunk, chunk_pl.written());
     try quic.streamDrainWrites(cli_chunk, srv, 10_000);
 
     rounds = 0;
@@ -607,7 +601,7 @@ test "QUIC origin RS outbound CHUNK (peerSendRsChunk + sessionDrainOutboundOverQ
     if (@import("builtin").os.tag == .windows) return error.SkipZigTest;
     if (@import("builtin").os.tag == .wasi) return error.SkipZigTest;
 
-    var gpa = std.heap.GeneralPurposeAllocator(.{}){};
+    var gpa = std.heap.DebugAllocator(.{}){};
     defer _ = gpa.deinit();
     var alloc = gpa.allocator();
 
@@ -699,30 +693,28 @@ test "QUIC origin RS outbound CHUNK (peerSendRsChunk + sessionDrainOutboundOverQ
         .peer_id = "client-peer",
     });
 
-    var srv_bcast_payload = std.ArrayList(u8).empty;
-    defer srv_bcast_payload.deinit(alloc);
+    var srv_bcast_payload = std.Io.Writer.Allocating.init(alloc);
+    defer srv_bcast_payload.deinit();
     {
-        const w = srv_bcast_payload.writer(alloc);
-        try bcast_stream.writeBcastHandshakeOpen(w, alloc, .{
+        try bcast_stream.writeBcastHandshakeOpen(&srv_bcast_payload.writer, alloc, .{
             .version = 1,
             .channels = &.{"ch1"},
             .peer_id = "server-peer",
         });
     }
-    try quic.streamQueueWrite(host.peer.bcast_out.?, srv_bcast_payload.items);
+    try quic.streamQueueWrite(host.peer.bcast_out.?, srv_bcast_payload.written());
     try quic.streamDrainWrites(host.peer.bcast_out.?, client_ep, 10_000);
 
-    var cli_bcast_payload = std.ArrayList(u8).empty;
-    defer cli_bcast_payload.deinit(alloc);
+    var cli_bcast_payload = std.Io.Writer.Allocating.init(alloc);
+    defer cli_bcast_payload.deinit();
     {
-        const w = cli_bcast_payload.writer(alloc);
-        try bcast_stream.writeBcastHandshakeOpen(w, alloc, .{
+        try bcast_stream.writeBcastHandshakeOpen(&cli_bcast_payload.writer, alloc, .{
             .version = 1,
             .channels = &.{"ch1"},
             .peer_id = "client-peer",
         });
     }
-    try quic.streamQueueWrite(cli_pc.bcast_out.?, cli_bcast_payload.items);
+    try quic.streamQueueWrite(cli_pc.bcast_out.?, cli_bcast_payload.written());
     try quic.streamDrainWrites(cli_pc.bcast_out.?, srv, 10_000);
 
     rounds = 0;
@@ -785,8 +777,8 @@ test "QUIC origin RS outbound CHUNK (peerSendRsChunk + sessionDrainOutboundOverQ
     const raw_in = quic.streamReadSlice(ust);
     try std.testing.expect(raw_in.len > 0);
 
-    var fbs = std.io.fixedBufferStream(raw_in);
-    var cin = try chunk_stream.readChunkStream(alloc, fbs.reader());
+    var fbs = std.Io.Reader.fixed(raw_in);
+    var cin = try chunk_stream.readChunkStream(alloc, &fbs);
     defer cin.deinit(alloc);
     try std.testing.expectEqualStrings("ch1", cin.header.channel);
     try std.testing.expectEqualStrings("m1", cin.header.message_id);

--- a/src/transport/eth_ec_quic_peer.zig
+++ b/src/transport/eth_ec_quic_peer.zig
@@ -88,10 +88,10 @@ pub const PeerConn = struct {
         const out = try quic.streamMakeUni(self.conn, poll_peer);
         self.bcast_out = out;
 
-        var buf = std.ArrayList(u8).empty;
-        defer buf.deinit(self.allocator);
-        try bcast_stream.writeBcastHandshakeOpen(buf.writer(self.allocator), self.allocator, hs);
-        try quic.streamQueueWrite(out, buf.items);
+        var aw = std.Io.Writer.Allocating.init(self.allocator);
+        defer aw.deinit();
+        try bcast_stream.writeBcastHandshakeOpen(&aw.writer, self.allocator, hs);
+        try quic.streamQueueWrite(out, aw.written());
 
         self.state = .handshaking;
     }

--- a/src/transport/shared_udp_socket.zig
+++ b/src/transport/shared_udp_socket.zig
@@ -12,6 +12,7 @@
 //! its internal timers and flush any queued outbound QUIC frames.
 
 const std = @import("std");
+const compat = @import("compat");
 const posix = std.posix;
 const discv5_node = @import("../discovery/discv5/node.zig");
 const eth_ec_quic = @import("eth_ec_quic.zig");
@@ -20,25 +21,25 @@ const max_datagram_len = 1500;
 
 pub const SharedUdpSocket = struct {
     sock: posix.socket_t,
-    local_addr: std.net.Address,
+    local_addr: compat.Address,
 
     /// Bind a new UDP socket to `0.0.0.0:port` (port 0 = OS-assigned).
     pub fn bind(port: u16) !SharedUdpSocket {
-        const addr = std.net.Address.initIp4(.{ 0, 0, 0, 0 }, port);
-        const sock = try posix.socket(
+        const addr = compat.Address.initIp4(.{ 0, 0, 0, 0 }, port);
+        const sock = try compat.socket(
             addr.any.family,
             posix.SOCK.DGRAM | posix.SOCK.NONBLOCK,
             posix.IPPROTO.UDP,
         );
-        errdefer posix.close(sock);
+        errdefer compat.close(sock);
 
         const reuse: c_int = 1;
         try posix.setsockopt(sock, posix.SOL.SOCKET, posix.SO.REUSEADDR, std.mem.asBytes(&reuse));
-        try posix.bind(sock, &addr.any, addr.getOsSockLen());
+        try compat.bind(sock, &addr.any, addr.getOsSockLen());
 
         var actual: posix.sockaddr = undefined;
         var actual_len: posix.socklen_t = @sizeOf(posix.sockaddr);
-        try posix.getsockname(sock, &actual, &actual_len);
+        try compat.getsockname(sock, &actual, &actual_len);
 
         return .{
             .sock = sock,
@@ -47,7 +48,7 @@ pub const SharedUdpSocket = struct {
     }
 
     pub fn deinit(self: *SharedUdpSocket) void {
-        posix.close(self.sock);
+        compat.close(self.sock);
     }
 
     /// The underlying file descriptor — pass to `discv5_node.startFromFd` and
@@ -57,7 +58,7 @@ pub const SharedUdpSocket = struct {
     }
 
     /// The address the socket is bound to (with the actual port when 0 was requested).
-    pub fn localAddr(self: *const SharedUdpSocket) std.net.Address {
+    pub fn localAddr(self: *const SharedUdpSocket) compat.Address {
         return self.local_addr;
     }
 
@@ -90,7 +91,7 @@ pub const SharedUdpSocket = struct {
         var from_len: posix.socklen_t = @sizeOf(posix.sockaddr);
 
         while (true) {
-            const n = posix.recvfrom(
+            const n = compat.recvfrom(
                 self.sock,
                 &buf,
                 posix.MSG.DONTWAIT,
@@ -98,7 +99,7 @@ pub const SharedUdpSocket = struct {
                 &from_len,
             ) catch break; // EAGAIN → no more datagrams
 
-            const peer = std.net.Address{ .any = from };
+            const peer = compat.Address{ .any = from };
 
             if (!discv5.injectDatagram(buf[0..n], peer)) {
                 // Not a discv5 packet — forward to QUIC.

--- a/src/transport/zquic_quic_shim.zig
+++ b/src/transport/zquic_quic_shim.zig
@@ -2,6 +2,7 @@
 //! Implemented with pure-Zig [zquic](https://github.com/ch4r10t33r/zquic) (TLS 1.3 + QUIC).
 
 const std = @import("std");
+const compat = @import("compat");
 const posix = std.posix;
 
 const zquic = @import("zquic");
@@ -26,8 +27,8 @@ pub fn logInit(_: []const u8) void {
 pub const QuicEndpoint = struct {
     allocator: *std.mem.Allocator,
     is_server: bool,
-    local_addr: std.net.Address,
-    resolved_local: ?std.net.Address = null,
+    local_addr: compat.Address,
+    resolved_local: ?compat.Address = null,
     accept_queue: std.ArrayListUnmanaged(*QuicConnection),
     connect_slot: ?*QuicConnection,
     first_alpn: []const u8,
@@ -43,28 +44,28 @@ pub const QuicEndpoint = struct {
     client_host_storage: ?[]u8 = null,
     sock: posix.socket_t = -1,
 
-    fn isWildcardLocal(addr: std.net.Address) bool {
+    fn isWildcardLocal(addr: compat.Address) bool {
         return switch (addr.any.family) {
             posix.AF.INET => {
-                const b: *const [4]u8 = @ptrCast(&addr.in.sa.addr);
+                const b: *const [4]u8 = @ptrCast(&addr.in.addr);
                 return std.mem.allEqual(u8, b, 0);
             },
             posix.AF.INET6 => {
-                const b: *const [16]u8 = @ptrCast(&addr.in6.sa.addr);
+                const b: *const [16]u8 = @ptrCast(&addr.in6.addr);
                 return std.mem.allEqual(u8, b, 0);
             },
             else => false,
         };
     }
 
-    fn resolveLocalForWildcard(local: std.net.Address, remote: std.net.Address) std.net.Address {
+    fn resolveLocalForWildcard(local: compat.Address, remote: compat.Address) compat.Address {
         if (!isWildcardLocal(local)) return local;
-        const sock = posix.socket(remote.any.family, posix.SOCK.DGRAM, posix.IPPROTO.UDP) catch return local;
-        defer posix.close(sock);
-        posix.connect(sock, &remote.any, remote.getOsSockLen()) catch return local;
-        var resolved: std.net.Address = undefined;
-        var len: posix.socklen_t = @sizeOf(std.net.Address);
-        posix.getsockname(sock, &resolved.any, &len) catch return local;
+        const sock = compat.socket(remote.any.family, posix.SOCK.DGRAM, posix.IPPROTO.UDP) catch return local;
+        defer compat.close(sock);
+        compat.connect(sock, &remote.any, remote.getOsSockLen()) catch return local;
+        var resolved: compat.Address = undefined;
+        var len: posix.socklen_t = @sizeOf(compat.Address);
+        compat.getsockname(sock, &resolved.any, &len) catch return local;
         resolved.setPort(local.getPort());
         return resolved;
     }
@@ -82,9 +83,9 @@ pub const QuicEndpoint = struct {
 
     fn recvOneIfAvailable(self: *QuicEndpoint) !bool {
         var buf: [65536]u8 = undefined;
-        var peer: std.net.Address = undefined;
-        var peer_len: posix.socklen_t = @sizeOf(std.net.Address);
-        const n = posix.recvfrom(self.sock, &buf, 0, &peer.any, &peer_len) catch |err| switch (err) {
+        var peer: compat.Address = undefined;
+        var peer_len: posix.socklen_t = @sizeOf(compat.Address);
+        const n = compat.recvfrom(self.sock, &buf, 0, &peer.any, &peer_len) catch |err| switch (err) {
             error.WouldBlock => return false,
             else => |e| return e,
         };
@@ -96,7 +97,7 @@ pub const QuicEndpoint = struct {
                     self.resolved_local = resolveLocalForWildcard(self.local_addr, peer);
                 }
             }
-            srv.feedPacket(buf[0..n], peer);
+            srv.feedPacket(buf[0..n], @bitCast(peer));
             srv.processPendingWork();
         } else if (self.client) |cli| {
             cli.feedPacket(buf[0..n]);
@@ -112,7 +113,7 @@ pub const QuicEndpoint = struct {
     fn scanServerAcceptsAndStreams(self: *QuicEndpoint) void {
         const srv = self.server orelse return;
         for (&srv.conns, 0..) |*slot, i| {
-            if (slot.*) |*conn| {
+            if (slot.*) |conn| {
                 if (conn.phase == .connected and conn.has_app_keys) {
                     if (self.server_conn_handles[i] == null) {
                         const qc = self.allocator.create(QuicConnection) catch continue;
@@ -166,9 +167,9 @@ pub const QuicConnection = struct {
             .server = ep.server,
             .server_slot = slot,
             .client = null,
-            .incoming_streams = .{},
-            .incoming_uni_streams = .{},
-            .streams_owned = .{},
+            .incoming_streams = .empty,
+            .incoming_uni_streams = .empty,
+            .streams_owned = .empty,
             .dispatched_incoming = std.AutoHashMap(u64, void).init(ep.allocator.*),
         };
     }
@@ -193,9 +194,9 @@ pub const QuicConnection = struct {
             .server = null,
             .server_slot = null,
             .client = cli,
-            .incoming_streams = .{},
-            .incoming_uni_streams = .{},
-            .streams_owned = .{},
+            .incoming_streams = .empty,
+            .incoming_uni_streams = .empty,
+            .streams_owned = .empty,
             .dispatched_incoming = std.AutoHashMap(u64, void).init(ep.allocator.*),
         };
     }
@@ -204,7 +205,7 @@ pub const QuicConnection = struct {
         if (self.is_client) return &self.client.?.conn;
         const srv = self.server orelse return null;
         const si = self.server_slot orelse return null;
-        if (srv.conns[si]) |*c| return c;
+        if (srv.conns[si]) |c| return c;
         return null;
     }
 
@@ -215,7 +216,7 @@ pub const QuicConnection = struct {
         }
         const srv = self.server orelse return null;
         const si = self.server_slot orelse return null;
-        if (srv.conns[si]) |*c| return c;
+        if (srv.conns[si]) |c| return c;
         return null;
     }
 
@@ -271,8 +272,8 @@ pub const QuicConnection = struct {
         st.* = .{
             .conn = self,
             .stream_id = sid,
-            .read_buf = .{},
-            .write_buf = .{},
+            .read_buf = .empty,
+            .write_buf = .empty,
             .write_off = 0,
             .is_incoming = true,
         };
@@ -300,18 +301,18 @@ pub const QuicConnection = struct {
 
 pub const QuicStream = QuicConnection.Stream;
 
-fn parseBindAddr(s: []const u8) !std.net.Address {
+fn parseBindAddr(s: []const u8) !compat.Address {
     const colon = std.mem.lastIndexOfScalar(u8, s, ':') orelse return error.BadAddress;
     const host = s[0..colon];
     const port = try std.fmt.parseInt(u16, s[colon + 1 ..], 10);
     if (host.len >= 2 and host[0] == '[' and host[host.len - 1] == ']') {
-        return try std.net.Address.parseIp(host[1 .. host.len - 1], port);
+        return try compat.Address.parseIp(host[1 .. host.len - 1], port);
     }
-    return try std.net.Address.parseIp(host, port);
+    return try compat.Address.parseIp(host, port);
 }
 
 fn resolveRepoPath(allocator: std.mem.Allocator, rel: []const u8) ![]const u8 {
-    const cwd = try std.fs.cwd().realpathAlloc(allocator, ".");
+    const cwd = try compat.getCwdAlloc(allocator);
     defer allocator.free(cwd);
     return std.fs.path.resolve(allocator, &.{ cwd, rel });
 }
@@ -333,15 +334,15 @@ pub fn endpointInit(allocator: *std.mem.Allocator, bind_s: []const u8, qc: *Quic
         const key_abs = try resolveRepoPath(allocator.*, key_path);
         errdefer allocator.free(key_abs);
 
-        const sock = try posix.socket(addr.any.family, posix.SOCK.DGRAM | posix.SOCK.NONBLOCK, posix.IPPROTO.UDP);
-        errdefer posix.close(sock);
+        const sock = try compat.socket(addr.any.family, posix.SOCK.DGRAM | posix.SOCK.NONBLOCK, posix.IPPROTO.UDP);
+        errdefer compat.close(sock);
         const reuse: c_int = 1;
         try posix.setsockopt(sock, posix.SOL.SOCKET, posix.SO.REUSEADDR, std.mem.asBytes(&reuse));
-        try posix.bind(sock, &addr.any, addr.getOsSockLen());
+        try compat.bind(sock, &addr.any, addr.getOsSockLen());
 
-        var local_addr: std.net.Address = undefined;
-        var la_len: posix.socklen_t = @sizeOf(std.net.Address);
-        try posix.getsockname(sock, &local_addr.any, &la_len);
+        var local_addr: compat.Address = undefined;
+        var la_len: posix.socklen_t = @sizeOf(compat.Address);
+        try compat.getsockname(sock, &local_addr.any, &la_len);
 
         const scfg = io.ServerConfig{
             .port = addr.getPort(),
@@ -358,7 +359,7 @@ pub fn endpointInit(allocator: *std.mem.Allocator, bind_s: []const u8, qc: *Quic
             .allocator = allocator,
             .is_server = true,
             .local_addr = local_addr,
-            .accept_queue = .{},
+            .accept_queue = .empty,
             .connect_slot = null,
             .first_alpn = first_alpn,
             .base_plpmtu = @truncate(qc.max_udp_payload),
@@ -371,16 +372,20 @@ pub fn endpointInit(allocator: *std.mem.Allocator, bind_s: []const u8, qc: *Quic
         return ep;
     }
 
-    const sock = try posix.socket(posix.AF.INET, posix.SOCK.DGRAM | posix.SOCK.NONBLOCK, posix.IPPROTO.UDP);
-    errdefer posix.close(sock);
-    try posix.bind(sock, &addr.any, addr.getOsSockLen());
-    var local_addr: std.net.Address = undefined;
-    var la_len: posix.socklen_t = @sizeOf(std.net.Address);
-    try posix.getsockname(sock, &local_addr.any, &la_len);
+    const sock = try compat.socket(posix.AF.INET, posix.SOCK.DGRAM | posix.SOCK.NONBLOCK, posix.IPPROTO.UDP);
+    errdefer compat.close(sock);
+    try compat.bind(sock, &addr.any, addr.getOsSockLen());
+    var local_addr: compat.Address = undefined;
+    var la_len: posix.socklen_t = @sizeOf(compat.Address);
+    try compat.getsockname(sock, &local_addr.any, &la_len);
 
     const cli = try allocator.create(io.Client);
     errdefer allocator.destroy(cli);
-    cli.* = try io.Client.initFromSocket(allocator.*, .{
+    // `Client` is a large struct; `initFromSocket` returns it by value (a huge
+    // stack copy that overflows). The socket is already bound above, so use the
+    // bound-socket in-place variant (which does not re-bind) to build directly
+    // into the heap allocation.
+    try io.Client.initFromBoundSocketInPlace(allocator.*, .{
         .host = "127.0.0.1",
         .port = 443,
         .urls = &.{},
@@ -388,13 +393,13 @@ pub fn endpointInit(allocator: *std.mem.Allocator, bind_s: []const u8, qc: *Quic
         .raw_application_streams = true,
         .http09 = false,
         .http3 = false,
-    }, sock, true);
+    }, sock, cli);
 
     ep.* = .{
         .allocator = allocator,
         .is_server = false,
         .local_addr = local_addr,
-        .accept_queue = .{},
+        .accept_queue = .empty,
         .connect_slot = null,
         .first_alpn = first_alpn,
         .base_plpmtu = @truncate(qc.max_udp_payload),
@@ -436,7 +441,7 @@ pub fn endpointDeinit(ep: *QuicEndpoint) void {
 pub fn endpointInitFromFd(
     allocator: *std.mem.Allocator,
     sock: posix.socket_t,
-    local_addr: std.net.Address,
+    local_addr: compat.Address,
     qc: *QuicConfig,
 ) !*QuicEndpoint {
     const first_alpn = qc.alpn.*[0];
@@ -463,7 +468,7 @@ pub fn endpointInitFromFd(
         .allocator = allocator,
         .is_server = true,
         .local_addr = local_addr,
-        .accept_queue = .{},
+        .accept_queue = .empty,
         .connect_slot = null,
         .first_alpn = first_alpn,
         .base_plpmtu = @truncate(qc.max_udp_payload),
@@ -476,10 +481,10 @@ pub fn endpointInitFromFd(
     return ep;
 }
 
-pub fn feedPacket(ep: *QuicEndpoint, data: []const u8, peer: std.net.Address, local: std.net.Address) void {
+pub fn feedPacket(ep: *QuicEndpoint, data: []const u8, peer: compat.Address, local: compat.Address) void {
     _ = local;
     if (ep.server) |srv| {
-        srv.feedPacket(data, peer);
+        srv.feedPacket(data, @bitCast(peer));
         srv.processPendingWork();
     }
     ep.scanServerAcceptsAndStreams();
@@ -503,9 +508,9 @@ pub fn connect(ep: *QuicEndpoint, remote_s: []const u8, hostname: []const u8) !*
     ep.client_host_storage = try ep.allocator.dupe(u8, hostname);
     cli.config.host = ep.client_host_storage.?;
     cli.config.port = remote.getPort();
-    cli.conn.peer = remote;
+    cli.conn.peer = @bitCast(remote);
 
-    try cli.startHandshake(remote);
+    try cli.startHandshake(@bitCast(remote));
 
     const qc = try ep.allocator.create(QuicConnection);
     qc.* = QuicConnection.initClient(ep, cli);
@@ -532,7 +537,7 @@ pub fn poll(ep: *QuicEndpoint, timeout_ms: u32) !void {
     }
     ep.scanServerAcceptsAndStreams();
     if (timeout_ms == 0) {
-        std.Thread.sleep(50 * std.time.ns_per_us);
+        compat.sleepNs(50 * std.time.ns_per_us);
     }
 }
 
@@ -579,8 +584,8 @@ pub fn streamMake(conn: *QuicConnection, poll_peer: ?*QuicEndpoint) !*QuicStream
     qs.* = .{
         .conn = conn,
         .stream_id = sid,
-        .read_buf = .{},
-        .write_buf = .{},
+        .read_buf = .empty,
+        .write_buf = .empty,
         .write_off = 0,
         .is_incoming = false,
     };
@@ -610,8 +615,8 @@ pub fn streamMakeUni(conn: *QuicConnection, poll_peer: ?*QuicEndpoint) !*QuicStr
     qs.* = .{
         .conn = conn,
         .stream_id = sid,
-        .read_buf = .{},
-        .write_buf = .{},
+        .read_buf = .empty,
+        .write_buf = .empty,
         .write_off = 0,
         .stream_send_off = 0,
         .is_incoming = false,
@@ -644,15 +649,17 @@ pub fn streamDrainWrites(st: *QuicStream, peer: *QuicEndpoint, max_rounds: u32) 
         const rest = st.write_buf.items[st.write_off..];
         const take = @min(rest.len, max_stream_chunk);
         const fin = take == rest.len;
-        if (st.conn.client) |c| {
-            c.sendRawStreamData(st.stream_id, st.stream_send_off, rest[0..take], fin);
-        } else {
+        // zquic 1.7.x `sendRawStreamData` returns the number of bytes accepted
+        // into the send buffer; advance by that rather than the requested size.
+        const sent = if (st.conn.client) |c|
+            c.sendRawStreamData(st.stream_id, st.stream_send_off, rest[0..take], fin)
+        else blk: {
             const srv = st.conn.server orelse return error.StreamWriteTimeout;
             const cs = st.conn.connStatePtr() orelse return error.StreamWriteTimeout;
-            srv.sendRawStreamData(cs, st.stream_id, st.stream_send_off, rest[0..take], fin);
-        }
-        st.stream_send_off += take;
-        st.write_off += take;
+            break :blk srv.sendRawStreamData(cs, st.stream_id, st.stream_send_off, rest[0..take], fin);
+        };
+        st.stream_send_off += sent;
+        st.write_off += sent;
         try poll(st.conn.ep, 0);
         try poll(peer, 0);
     }

--- a/src/wire/bcast_stream.zig
+++ b/src/wire/bcast_stream.zig
@@ -10,7 +10,7 @@ pub const BcastStreamError = error{
 
 /// Writes one length-prefixed `Bcast` frame (no selector). Matches
 /// `PeerConn.writeCtrl` / `WriteFrame` on `ctrlOut`.
-pub fn writeBcastCtrlFrame(writer: anytype, allocator: std.mem.Allocator, msg: broadcast.Bcast) !void {
+pub fn writeBcastCtrlFrame(writer: *std.Io.Writer, allocator: std.mem.Allocator, msg: broadcast.Bcast) !void {
     const bytes = try broadcast.encodeBcast(allocator, msg);
     defer allocator.free(bytes);
     try frame.writeFrame(writer, bytes);
@@ -18,7 +18,7 @@ pub fn writeBcastCtrlFrame(writer: anytype, allocator: std.mem.Allocator, msg: b
 
 /// Reads one `Bcast` frame. Matches `runCtrlReader`’s `ReadFrame` loop on `ctrlIn`
 /// (after the peer’s stream was accepted and the selector was validated elsewhere).
-pub fn readBcastCtrlFrame(allocator: std.mem.Allocator, reader: anytype) !broadcast.BcastOwned {
+pub fn readBcastCtrlFrame(allocator: std.mem.Allocator, reader: *std.Io.Reader) !broadcast.BcastOwned {
     const bytes = try frame.readFrame(allocator, reader);
     defer allocator.free(bytes);
     return broadcast.decodeBcast(allocator, bytes);
@@ -26,14 +26,14 @@ pub fn readBcastCtrlFrame(allocator: std.mem.Allocator, reader: anytype) !broadc
 
 /// Outbound BCAST stream start: selector `PROTOCOL_BCAST` then handshake frame.
 /// Matches the writer side of `PeerConn.handshake` (`peer.go`).
-pub fn writeBcastHandshakeOpen(writer: anytype, allocator: std.mem.Allocator, hs: broadcast.Handshake) !void {
+pub fn writeBcastHandshakeOpen(writer: *std.Io.Writer, allocator: std.mem.Allocator, hs: broadcast.Handshake) !void {
     try protocol.writeSelectorByte(writer, .bcast);
     try writeBcastCtrlFrame(writer, allocator, .{ .peer_handshake = hs });
 }
 
 /// Inbound BCAST stream: read selector, then first frame must be `peer_handshake`.
 /// Matches the reader side of `PeerConn.handshake`.
-pub fn readBcastPeerHandshake(allocator: std.mem.Allocator, reader: anytype) !broadcast.BcastOwned {
+pub fn readBcastPeerHandshake(allocator: std.mem.Allocator, reader: *std.Io.Reader) !broadcast.BcastOwned {
     const sel = try protocol.readSelectorByte(reader);
     if (sel != .bcast) return error.WrongBcastStream;
     var msg = try readBcastCtrlFrame(allocator, reader);
@@ -51,20 +51,19 @@ test "bcast handshake open matches reference layout" {
     var golden_buf: [64]u8 = undefined;
     const golden = try std.fmt.hexToBytes(&golden_buf, "01000000190a1708011206626c6f636b731204617474731a057065657231");
 
-    var list = std.ArrayList(u8).empty;
-    defer list.deinit(alloc);
+    var aw = std.Io.Writer.Allocating.init(alloc);
+    defer aw.deinit();
     {
-        const w = list.writer(alloc);
-        try writeBcastHandshakeOpen(w, alloc, .{
+        try writeBcastHandshakeOpen(&aw.writer, alloc, .{
             .version = 1,
             .channels = &.{ "blocks", "atts" },
             .peer_id = "peer1",
         });
     }
-    try std.testing.expectEqualSlices(u8, golden, list.items);
+    try std.testing.expectEqualSlices(u8, golden, aw.written());
 
-    var fbs = std.io.fixedBufferStream(list.items);
-    var hs = try readBcastPeerHandshake(alloc, fbs.reader());
+    var fbs = std.Io.Reader.fixed(aw.written());
+    var hs = try readBcastPeerHandshake(alloc, &fbs);
     defer hs.deinit(alloc);
     switch (hs) {
         .peer_handshake => |h| {

--- a/src/wire/chunk_stream.zig
+++ b/src/wire/chunk_stream.zig
@@ -28,13 +28,13 @@ pub const ChunkIn = struct {
 /// Writes a full CHUNK uni stream: selector byte, length-framed protobuf
 /// `Chunk.Header`, then raw payload. Matches `PeerConn.doSendChunk`.
 pub fn writeChunkStream(
-    writer: anytype,
+    writer: *std.Io.Writer,
     allocator: std.mem.Allocator,
     channel: []const u8,
     message_id: []const u8,
     chunk_id: []const u8,
     payload: []const u8,
-) (@TypeOf(writer).Error || frame.FrameError || std.mem.Allocator.Error || ChunkStreamError)!void {
+) (std.Io.Writer.Error || frame.FrameError || std.mem.Allocator.Error || ChunkStreamError)!void {
     if (payload.len > max_chunk_data_size) return error.ChunkPayloadTooLarge;
 
     try protocol.writeSelectorByte(writer, .chunk);
@@ -54,27 +54,27 @@ pub fn writeChunkStream(
 /// `Chunk.Header.chunk_id` carries `proto.Marshal(rspb.ChunkIdent{index})`, as in
 /// `broadcast/rs/types.go` `ChunkIdent.Marshal`.
 pub fn writeRsShardChunk(
-    writer: anytype,
+    writer: *std.Io.Writer,
     allocator: std.mem.Allocator,
     channel: []const u8,
     message_id: []const u8,
     shard_index: i32,
     payload: []const u8,
-) (@TypeOf(writer).Error || frame.FrameError || std.mem.Allocator.Error || ChunkStreamError)!void {
+) (std.Io.Writer.Error || frame.FrameError || std.mem.Allocator.Error || ChunkStreamError)!void {
     const chunk_id = try rs.encodeChunkIdent(allocator, .{ .index = shard_index });
     defer allocator.free(chunk_id);
     try writeChunkStream(writer, allocator, channel, message_id, chunk_id, payload);
 }
 
 /// Reads selector, header frame, and payload. Caller must `ChunkIn.deinit`.
-pub fn readChunkStream(allocator: std.mem.Allocator, reader: anytype) !ChunkIn {
+pub fn readChunkStream(allocator: std.mem.Allocator, reader: *std.Io.Reader) !ChunkIn {
     const sel = try protocol.readSelectorByte(reader);
     if (sel != .chunk) return error.NotChunkStream;
     return readChunkAfterSelector(allocator, reader);
 }
 
 /// Reads header frame + payload when `PROTOCOL_CHUNK` was already read.
-pub fn readChunkAfterSelector(allocator: std.mem.Allocator, reader: anytype) !ChunkIn {
+pub fn readChunkAfterSelector(allocator: std.mem.Allocator, reader: *std.Io.Reader) !ChunkIn {
     const header_pb = try frame.readFrame(allocator, reader);
     errdefer allocator.free(header_pb);
 
@@ -86,7 +86,7 @@ pub fn readChunkAfterSelector(allocator: std.mem.Allocator, reader: anytype) !Ch
 
     const payload = try allocator.alloc(u8, header.data_length);
     errdefer allocator.free(payload);
-    try reader.readNoEof(payload);
+    try reader.readSliceAll(payload);
 
     return .{
         .header = header,
@@ -99,16 +99,15 @@ test "chunk stream golden matches reference encoder" {
     var golden_buf: [64]u8 = undefined;
     const golden = try std.fmt.hexToBytes(&golden_buf, "030000000b0a016312016d1a01092002aabb");
 
-    var list = std.ArrayList(u8).empty;
-    defer list.deinit(alloc);
+    var aw = std.Io.Writer.Allocating.init(alloc);
+    defer aw.deinit();
     {
-        const w = list.writer(alloc);
-        try writeChunkStream(w, alloc, "c", "m", &.{9}, &.{ 0xAA, 0xBB });
+        try writeChunkStream(&aw.writer, alloc, "c", "m", &.{9}, &.{ 0xAA, 0xBB });
     }
-    try std.testing.expectEqualSlices(u8, golden, list.items);
+    try std.testing.expectEqualSlices(u8, golden, aw.written());
 
-    var fbs = std.io.fixedBufferStream(list.items);
-    var got = try readChunkStream(alloc, fbs.reader());
+    var fbs = std.Io.Reader.fixed(aw.written());
+    var got = try readChunkStream(alloc, &fbs);
     defer got.deinit(alloc);
     try std.testing.expectEqualStrings("c", got.header.channel);
     try std.testing.expectEqualStrings("m", got.header.message_id);
@@ -122,16 +121,15 @@ test "rs shard chunk stream matches reference (ChunkIdent in header)" {
     var golden_buf: [64]u8 = undefined;
     const golden = try std.fmt.hexToBytes(&golden_buf, "030000000c0a016312016d1a0208072001ff");
 
-    var list = std.ArrayList(u8).empty;
-    defer list.deinit(alloc);
+    var aw = std.Io.Writer.Allocating.init(alloc);
+    defer aw.deinit();
     {
-        const w = list.writer(alloc);
-        try writeRsShardChunk(w, alloc, "c", "m", 7, &.{0xFF});
+        try writeRsShardChunk(&aw.writer, alloc, "c", "m", 7, &.{0xFF});
     }
-    try std.testing.expectEqualSlices(u8, golden, list.items);
+    try std.testing.expectEqualSlices(u8, golden, aw.written());
 
-    var fbs = std.io.fixedBufferStream(list.items);
-    var got = try readChunkStream(alloc, fbs.reader());
+    var fbs = std.Io.Reader.fixed(aw.written());
+    var got = try readChunkStream(alloc, &fbs);
     defer got.deinit(alloc);
     const ident = try rs.decodeChunkIdent(alloc, got.header.chunk_id);
     try std.testing.expectEqual(@as(i32, 7), ident.index);
@@ -142,8 +140,8 @@ test "readChunkAfterSelector matches processChunk framing" {
     // After selector 0x03: framed header + payload only
     var golden_buf: [64]u8 = undefined;
     const after_sel = try std.fmt.hexToBytes(&golden_buf, "0000000b0a016312016d1a01092002aabb");
-    var fbs = std.io.fixedBufferStream(after_sel);
-    var got = try readChunkAfterSelector(alloc, fbs.reader());
+    var fbs = std.Io.Reader.fixed(after_sel);
+    var got = try readChunkAfterSelector(alloc, &fbs);
     defer got.deinit(alloc);
     try std.testing.expectEqualSlices(u8, &.{ 0xAA, 0xBB }, got.payload);
 }

--- a/src/wire/frame.zig
+++ b/src/wire/frame.zig
@@ -9,7 +9,7 @@ pub const FrameError = error{
 
 /// Writes a length-prefixed payload: 4-byte big-endian length then bytes.
 /// Matches `broadcast.WriteFrame` in github.com/ethp2p/ethp2p.
-pub fn writeFrame(writer: anytype, payload: []const u8) (@TypeOf(writer).Error || FrameError)!void {
+pub fn writeFrame(writer: *std.Io.Writer, payload: []const u8) (std.Io.Writer.Error || FrameError)!void {
     if (payload.len > max_frame_size) return error.FrameTooLarge;
     var len_buf: [4]u8 = undefined;
     std.mem.writeInt(u32, &len_buf, @intCast(payload.len), .big);
@@ -18,30 +18,29 @@ pub fn writeFrame(writer: anytype, payload: []const u8) (@TypeOf(writer).Error |
 }
 
 /// Reads one frame into memory allocated with `allocator`. Caller owns the returned slice.
-pub fn readFrame(allocator: std.mem.Allocator, reader: anytype) ![]u8 {
+pub fn readFrame(allocator: std.mem.Allocator, reader: *std.Io.Reader) ![]u8 {
     var len_buf: [4]u8 = undefined;
-    try reader.readNoEof(&len_buf);
+    try reader.readSliceAll(&len_buf);
     const length = std.mem.readInt(u32, &len_buf, .big);
     if (length > max_frame_size) return error.FrameTooLarge;
     const data = try allocator.alloc(u8, length);
     errdefer allocator.free(data);
-    try reader.readNoEof(data);
+    try reader.readSliceAll(data);
     return data;
 }
 
 test "writeFrame readFrame roundtrip" {
     const alloc = std.testing.allocator;
-    var list = std.ArrayList(u8).empty;
-    defer list.deinit(alloc);
+    var aw = std.Io.Writer.Allocating.init(alloc);
+    defer aw.deinit();
 
     const payload = "hello ethp2p";
     {
-        const w = list.writer(alloc);
-        try writeFrame(w, payload);
+        try writeFrame(&aw.writer, payload);
     }
 
-    var stream = std.io.fixedBufferStream(list.items);
-    const out = try readFrame(alloc, stream.reader());
+    var stream = std.Io.Reader.fixed(aw.written());
+    const out = try readFrame(alloc, &stream);
     defer alloc.free(out);
     try std.testing.expectEqualStrings(payload, out);
 }
@@ -51,15 +50,14 @@ test "framed payload preserves reference bcast handshake bytes" {
     var inner_buf: [32]u8 = undefined;
     const inner = try std.fmt.hexToBytes(&inner_buf, "0a1708011206626c6f636b731204617474731a057065657231");
 
-    var list = std.ArrayList(u8).empty;
-    defer list.deinit(alloc);
+    var aw = std.Io.Writer.Allocating.init(alloc);
+    defer aw.deinit();
     {
-        const w = list.writer(alloc);
-        try writeFrame(w, inner);
+        try writeFrame(&aw.writer, inner);
     }
 
-    var stream = std.io.fixedBufferStream(list.items);
-    const round = try readFrame(alloc, stream.reader());
+    var stream = std.Io.Reader.fixed(aw.written());
+    const round = try readFrame(alloc, &stream);
     defer alloc.free(round);
     try std.testing.expectEqualSlices(u8, inner, round);
 }

--- a/src/wire/protocol.zig
+++ b/src/wire/protocol.zig
@@ -16,34 +16,33 @@ pub const Protocol = enum(u8) {
 pub const ErrUnspecified = error{ProtocolUnspecified};
 
 /// Matches `protocol.WriteSelector`.
-pub fn writeSelectorByte(writer: anytype, p: Protocol) @TypeOf(writer).Error!void {
+pub fn writeSelectorByte(writer: *std.Io.Writer, p: Protocol) std.Io.Writer.Error!void {
     try writer.writeAll(&.{@intFromEnum(p)});
 }
 
 /// Matches `protocol.ReadSelector` (rejects `PROTOCOL_UNSPECIFIED`).
-pub fn readSelectorByte(reader: anytype) !Protocol {
+pub fn readSelectorByte(reader: *std.Io.Reader) !Protocol {
     var b: [1]u8 = undefined;
-    try reader.readNoEof(&b);
+    try reader.readSliceAll(&b);
     if (b[0] == 0) return error.ProtocolUnspecified;
     return @enumFromInt(b[0]);
 }
 
 test "selector byte matches reference (BCAST = 0x01)" {
-    var list = std.ArrayList(u8).empty;
-    defer list.deinit(std.testing.allocator);
+    var aw = std.Io.Writer.Allocating.init(std.testing.allocator);
+    defer aw.deinit();
     {
-        const w = list.writer(std.testing.allocator);
-        try writeSelectorByte(w, .bcast);
+        try writeSelectorByte(&aw.writer, .bcast);
     }
-    try std.testing.expectEqualSlices(u8, &.{0x01}, list.items);
+    try std.testing.expectEqualSlices(u8, &.{0x01}, aw.written());
 
-    var fbs = std.io.fixedBufferStream(list.items);
-    const p = try readSelectorByte(fbs.reader());
+    var fbs = std.Io.Reader.fixed(aw.written());
+    const p = try readSelectorByte(&fbs);
     try std.testing.expectEqual(Protocol.bcast, p);
 }
 
 test "readSelectorByte rejects unspecified" {
     var buf = [_]u8{0};
-    var fbs = std.io.fixedBufferStream(&buf);
-    try std.testing.expectError(error.ProtocolUnspecified, readSelectorByte(fbs.reader()));
+    var fbs = std.Io.Reader.fixed(&buf);
+    try std.testing.expectError(error.ProtocolUnspecified, readSelectorByte(&fbs));
 }

--- a/src/wire/sess_stream.zig
+++ b/src/wire/sess_stream.zig
@@ -7,14 +7,14 @@ pub const SessStreamError = error{ExpectedSessionOpen};
 
 /// Writes one length-prefixed `Sess` frame (no selector). Matches
 /// `WriteFrame` on an outbound SESS stream after the opener.
-pub fn writeSessFrame(writer: anytype, allocator: std.mem.Allocator, msg: broadcast.Sess) !void {
+pub fn writeSessFrame(writer: *std.Io.Writer, allocator: std.mem.Allocator, msg: broadcast.Sess) !void {
     const bytes = try broadcast.encodeSess(allocator, msg);
     defer allocator.free(bytes);
     try frame.writeFrame(writer, bytes);
 }
 
 /// Reads one `Sess` frame. Used for both the first open and subsequent routing updates.
-pub fn readSessFrame(allocator: std.mem.Allocator, reader: anytype) !broadcast.SessOwned {
+pub fn readSessFrame(allocator: std.mem.Allocator, reader: *std.Io.Reader) !broadcast.SessOwned {
     const bytes = try frame.readFrame(allocator, reader);
     defer allocator.free(bytes);
     return broadcast.decodeSess(allocator, bytes);
@@ -22,14 +22,14 @@ pub fn readSessFrame(allocator: std.mem.Allocator, reader: anytype) !broadcast.S
 
 /// Opens an outbound SESS stream: selector `PROTOCOL_SESS` then `session_open`.
 /// Matches `PeerConn.handleSessionOpen` (`peer_ctrl.go`).
-pub fn writeSessSessionOpen(writer: anytype, allocator: std.mem.Allocator, open: broadcast.SessOpen) !void {
+pub fn writeSessSessionOpen(writer: *std.Io.Writer, allocator: std.mem.Allocator, open: broadcast.SessOpen) !void {
     try protocol.writeSelectorByte(writer, .sess);
     try writeSessFrame(writer, allocator, .{ .session_open = open });
 }
 
 /// After `PROTOCOL_SESS` was read (e.g. in an accept loop), the first frame MUST be
 /// `session_open`. Matches `runInboundSession`’s first `ReadFrame` (`peer_in.go`).
-pub fn readSessSessionOpenAfterSelector(allocator: std.mem.Allocator, reader: anytype) !broadcast.SessOwned {
+pub fn readSessSessionOpenAfterSelector(allocator: std.mem.Allocator, reader: *std.Io.Reader) !broadcast.SessOwned {
     var msg = try readSessFrame(allocator, reader);
     switch (msg) {
         .session_open => return msg,
@@ -45,23 +45,22 @@ test "sess session open matches reference layout" {
     var golden_buf: [64]u8 = undefined;
     const golden = try std.fmt.hexToBytes(&golden_buf, "02000000150a130a0363683112036d69641a0301020322020405");
 
-    var list = std.ArrayList(u8).empty;
-    defer list.deinit(alloc);
+    var aw = std.Io.Writer.Allocating.init(alloc);
+    defer aw.deinit();
     {
-        const w = list.writer(alloc);
-        try writeSessSessionOpen(w, alloc, .{
+        try writeSessSessionOpen(&aw.writer, alloc, .{
             .channel = "ch1",
             .message_id = "mid",
             .preamble = &.{ 1, 2, 3 },
             .initial_update = &.{ 4, 5 },
         });
     }
-    try std.testing.expectEqualSlices(u8, golden, list.items);
+    try std.testing.expectEqualSlices(u8, golden, aw.written());
 
-    var fbs = std.io.fixedBufferStream(list.items);
-    const sel = try protocol.readSelectorByte(fbs.reader());
+    var fbs = std.Io.Reader.fixed(aw.written());
+    const sel = try protocol.readSelectorByte(&fbs);
     try std.testing.expectEqual(protocol.Protocol.sess, sel);
-    var open = try readSessSessionOpenAfterSelector(alloc, fbs.reader());
+    var open = try readSessSessionOpenAfterSelector(alloc, &fbs);
     defer open.deinit(alloc);
     switch (open) {
         .session_open => |o| {
@@ -74,14 +73,13 @@ test "sess session open matches reference layout" {
 
 test "sess routing update roundtrip after open" {
     const alloc = std.testing.allocator;
-    var list = std.ArrayList(u8).empty;
-    defer list.deinit(alloc);
+    var aw = std.Io.Writer.Allocating.init(alloc);
+    defer aw.deinit();
     {
-        const w = list.writer(alloc);
-        try writeSessFrame(w, alloc, .{ .routing_update = .{ .data = &.{ 0xAB, 0xCD } } });
+        try writeSessFrame(&aw.writer, alloc, .{ .routing_update = .{ .data = &.{ 0xAB, 0xCD } } });
     }
-    var fbs = std.io.fixedBufferStream(list.items);
-    var upd = try readSessFrame(alloc, fbs.reader());
+    var fbs = std.Io.Reader.fixed(aw.written());
+    var upd = try readSessFrame(alloc, &fbs);
     defer upd.deinit(alloc);
     switch (upd) {
         .routing_update => |u| try std.testing.expectEqualSlices(u8, &.{ 0xAB, 0xCD }, u.data),


### PR DESCRIPTION
Migrates zig-ethp2p to **Zig 0.16.0** (from 0.15.1).

## Why it's more than a version bump
0.16 folded `std.net`, the `std.io` reader/writer, `std.crypto.random`, `std.process.getEnvVarOwned`, the `std.posix` socket helpers, and `std.Thread.Mutex`/`Pool`/`WaitGroup` into the new `std.Io` abstraction. This library drives its own poll loop (via zquic) and doesn't need the `std.Io` async machinery, so — mirroring zquic's own `compat.zig` — it reinstates the removed APIs over raw syscalls rather than plumbing an `Io` instance through the whole library.

## Changes
- **New `src/compat.zig`** (dependency-free, wired as a build module):
  - `Address` / `Ip4Address` / `Ip6Address` (← `std.net`)
  - `random` OS CSPRNG (← `std.crypto.random`)
  - `socket`/`bind`/`connect`/`sendto`/`recvfrom`/`getsockname`/`close`, with `NONBLOCK`/`CLOEXEC` applied via `fcntl` (portable Linux/Darwin — the old `std.posix.socket` translated those Zig-abstract flag bits)
  - `Mutex` / `Pool` / `WaitGroup` (← `std.Thread.*`), over `std.Thread.spawn`
  - `getEnvVarOwned`, `getCwdAlloc`, `sleepNs`
- **Bump zquic `v1.5.0` → `v1.7.66`** (first 0.16-ready release).
- `ArrayList .{}` → `.empty`; `GeneralPurposeAllocator` → `DebugAllocator`.
- **Writergate**: wire encoders take `*std.Io.Writer` / `*std.Io.Reader`; call sites use `std.Io.Writer.Allocating` / `std.Io.Reader.fixed`.
- secp256k1 `KeyPair.generate()` → `generateDeterministic(seed)`.
- **zquic 1.7.x shim adaptation**: boxed `ConnState` slab captures; bound-socket in-place client init (`initFromBoundSocketInPlace`) to avoid a large by-value `Client` stack copy that segfaulted; `sendRawStreamData` now returns bytes-accepted and offsets advance by it.
- `build.zig`: expose `compat` module; toolchain pinned to `0.16.0` (`build.zig.zon` + `ci.yml`).

## Verification (stock Zig 0.16.0 from ziglang.org)
`zig fmt --check`, `zig build`, and the full test matrix pass locally: `test`, `test-broadcast`, `test-sim-rs`, `test-sim-gossipsub`, `test-quic`, `test-stress`.