### PR TITLE
broadcast: implement Observer interface + NoOpObserver + SessionRole

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,8 @@ Zig helpers for the wire formats of **[ethp2p](https://github.com/ethp2p/ethp2p)
 | CHUNK uni-stream | [`broadcast/peer_ctrl.go`](https://github.com/ethp2p/ethp2p/blob/main/broadcast/peer_ctrl.go) `doSendChunk`, [`peer_in.go`](https://github.com/ethp2p/ethp2p/blob/main/broadcast/peer_in.go) `processChunk` | `wire.chunk_stream` |
 | RS `Preamble` / `ChunkIdent` | [`broadcast/rs/pb`](https://github.com/ethp2p/ethp2p/tree/main/broadcast/rs/pb), [`broadcast/rs/types.go`](https://github.com/ethp2p/ethp2p/blob/main/broadcast/rs/types.go) | `wire.rs`, `writeRsShardChunk` |
 | Protocol version constant | [`broadcast/types.go`](https://github.com/ethp2p/ethp2p/blob/main/broadcast/types.go) `ProtocolV1` | `wire.constants.protocol_v1` |
-| `Verdict` / `ChunkHandle` | [`broadcast/types.go`](https://github.com/ethp2p/ethp2p/blob/main/broadcast/types.go) | `layer.broadcast_types` |
+| `Verdict` / `ChunkHandle` / `SessionRole` | [`broadcast/types.go`](https://github.com/ethp2p/ethp2p/blob/main/broadcast/types.go), [`broadcast/observer.go`](https://github.com/ethp2p/ethp2p/blob/main/broadcast/observer.go) | `layer.broadcast_types` |
+| Broadcast event `Observer` interface + `NoOpObserver` (15 callbacks, type-erased vtable) — emitted for channel-attach, session start/decode, chunk receive, peer subscribe/unsubscribe (remaining callbacks land with their subsystems) | [`broadcast/observer.go`](https://github.com/ethp2p/ethp2p/blob/main/broadcast/observer.go) | `broadcast.observer` |
 | `DedupCancel` + `DedupGroup` token (session hook) | session → strategy `takeChunk` | `layer.broadcast_types`, `layer.dedup` |
 | Engine-wide dedup registry (`channel` + `message` + chunk index) | multi-peer ingest dedup | `layer.dedup_registry`, `Engine.enable_cross_session_dedup` |
 | Verify result FIFO (single-threaded `Verified()` shim) | async verify channels | `layer.verify_queue` |
@@ -39,6 +40,7 @@ Zig helpers for the wire formats of **[ethp2p](https://github.com/ethp2p/ethp2p)
 | `PartialMessagesExtension` (nested in `RPC.partial`) | libp2p `rpc.proto` field 10 body | `encodePartialMessagesExtension`, `decodePartialMessagesExtensionOwned` |
 | Unsigned-varint length prefix before `RPC` body | common libp2p framing | `encodeRpcLengthPrefixed`, `decodeRpcLengthPrefixedPrefix` |
 | In-process duplex for length-prefixed `RPC` (simnet-style, no TCP/QUIC) | pair of `Endpoint`s over bounded byte queues | `sim.gossipsub_rpc_host` (`Link`, `Endpoint.sendRpc` / `recvRpcOwned`) |
+| Broadcast trace writer (`.bctrace` NDJSON: header / event tuples / 100 ms footer time index; golden bytes from the Go writer) | [`sim/trace_writer.go`](https://github.com/ethp2p/ethp2p/blob/main/sim/trace_writer.go) | `sim.trace_writer` |
 | QUIC transport + UNI stream alignment | [`sim/host.go`](https://github.com/ethp2p/ethp2p/blob/main/sim/host.go), `peer.go`, `peer_ctrl.go`, `peer_in.go` | `transport.eth_ec_quic`: IETF QUIC, TLS 1.3, ALPN `eth-ec-broadcast`, **unidirectional** BCAST/SESS/CHUNK streams matching `OpenUniStream`/`AcceptUniStream`; `PeerConn` + `broadcast.engine_quic` (`EngineQuicHost`) wire inbound SESS/CHUNK into `Engine` / `ChannelRs`. See [QUIC transport](#quic-transport-zquic). |
 | **Still open** | — | [Pending work](#pending-work) |
 
@@ -96,7 +98,7 @@ All ethp2p application protocols use UNI streams — both peers independently op
 
 ## Requirements
 
-- Zig **0.15.1** or newer.
+- Zig **0.16.0** or newer. (The `std.Io` reorg — `std.net`, the `std.io` reader/writer, `std.crypto.random`, and `std.Thread.Mutex`/`Pool` — is bridged by the dependency-free `src/compat.zig` shim.)
 
 ## Build
 

--- a/src/broadcast/channel_rs.zig
+++ b/src/broadcast/channel_rs.zig
@@ -60,6 +60,7 @@ pub const ChannelRs = struct {
         const dup = try self.allocator.dupe(u8, peer_id);
         errdefer self.allocator.free(dup);
         try self.members.append(self.allocator, dup);
+        self.engine.config.observer.peerSubscribed(peer_id, self.id);
     }
 
     pub fn removeMember(self: *ChannelRs, peer_id: []const u8) void {
@@ -67,6 +68,7 @@ pub const ChannelRs = struct {
             if (std.mem.eql(u8, m, peer_id)) {
                 self.allocator.free(m);
                 _ = self.members.swapRemove(i);
+                self.engine.config.observer.peerUnsubscribed(peer_id, self.id);
                 return;
             }
         }
@@ -113,6 +115,7 @@ pub const ChannelRs = struct {
         strat = null;
 
         try self.sessions.put(self.allocator, mid, sess);
+        self.engine.config.observer.sessionStarted(self.id, mid, .origin);
     }
 
     /// Relay-side session for an existing preamble (same members as `publish`).
@@ -155,6 +158,7 @@ pub const ChannelRs = struct {
         };
 
         try self.sessions.put(self.allocator, mid, sess);
+        self.engine.config.observer.sessionStarted(self.id, mid, .relay);
     }
 
     pub fn sessionDrainOutbound(self: *ChannelRs, message_id: []const u8) !usize {
@@ -175,7 +179,11 @@ pub const ChannelRs = struct {
 
     pub fn sessionDecode(self: *ChannelRs, message_id: []const u8) ![]u8 {
         const slot = self.sessions.getPtr(message_id) orelse return error.InvalidMessage;
-        return slot.*.strategy.decode();
+        const out = try slot.*.strategy.decode();
+        // Latency is not tracked in the Zig port yet (no per-session start clock);
+        // emit 0 for now — Go passes `time.Since(session.start)`.
+        self.engine.config.observer.sessionDecoded(self.id, message_id, 0);
+        return out;
     }
 
     /// After a successful decode, clears engine `DedupRegistry` keys for this `(channel_id, message_id)`
@@ -204,13 +212,15 @@ pub const ChannelRs = struct {
         dedup: ?*broadcast_types.DedupCancel,
     ) (Allocator.Error || errors.Error)!broadcast_types.ChunkIngestResult {
         const strat = self.sessionStrategy(message_id) orelse return error.InvalidMessage;
-        if (registry) |reg| {
-            const first = try reg.claim(self.allocator, self.id, message_id, chunk_id.index);
-            if (!first) {
-                return .{ .verdict = .redundant, .complete = false };
+        const result: broadcast_types.ChunkIngestResult = blk: {
+            if (registry) |reg| {
+                const first = try reg.claim(self.allocator, self.id, message_id, chunk_id.index);
+                if (!first) break :blk .{ .verdict = .redundant, .complete = false };
             }
-        }
-        return strat.takeChunk(peer, chunk_id, data, dedup);
+            break :blk try strat.takeChunk(peer, chunk_id, data, dedup);
+        };
+        self.engine.config.observer.chunkRcvd(peer, self.id, message_id, result.verdict);
+        return result;
     }
 
     /// `relayIngestChunk` using the engine-owned registry when cross-session dedup is enabled; otherwise `null`.
@@ -238,6 +248,7 @@ pub const ChannelRs = struct {
         const strat = self.sessionStrategy(message_id) orelse return error.InvalidMessage;
         const v = strat.verifyChunk(chunk_id, data);
         if (v != .accepted) {
+            self.engine.config.observer.chunkRcvd(peer, self.id, message_id, v);
             return .{ .verdict = v, .complete = false };
         }
         return self.relayIngestChunk(registry, message_id, peer, chunk_id, data, dedup);
@@ -282,6 +293,36 @@ test "channel publish and drain to one member" {
     const decoded = try ch.sessionDecode("m1");
     defer gpa.free(decoded);
     try std.testing.expectEqualSlices(u8, &payload, decoded);
+}
+
+test "observer receives channel/peer/session events" {
+    const gpa = std.testing.allocator;
+    var rec: @import("observer.zig").Recording = .{};
+
+    var eng = try Engine.init(gpa, "local", .{ .observer = rec.observer() });
+    defer eng.deinit();
+
+    const cfg = RsConfig{
+        .data_shards = 4,
+        .parity_shards = 2,
+        .chunk_len = 0,
+        .bitmap_threshold = 0,
+        .forward_multiplier = 4,
+        .disable_bitmap = false,
+    };
+
+    const ch = try eng.attachChannelRs("topic", cfg);
+    try ch.addMember("p1");
+    const payload = [_]u8{ 'h', 'e', 'l', 'l', 'o' };
+    try ch.publish("m1", &payload);
+    const decoded = try ch.sessionDecode("m1");
+    defer gpa.free(decoded);
+
+    try std.testing.expectEqual(@as(usize, 1), rec.channel_attached);
+    try std.testing.expectEqual(@as(usize, 1), rec.peer_subscribed);
+    try std.testing.expectEqual(@as(usize, 1), rec.session_started);
+    try std.testing.expectEqual(@import("../layer/broadcast_types.zig").SessionRole.origin, rec.last_role.?);
+    try std.testing.expectEqual(@as(usize, 1), rec.session_decoded);
 }
 
 test "relay ingest registry blocks second claim same chunk index" {

--- a/src/broadcast/engine.zig
+++ b/src/broadcast/engine.zig
@@ -11,7 +11,7 @@ const Allocator = std.mem.Allocator;
 pub const Error = errors.Error;
 
 pub const EngineConfig = struct {
-    observer: observer_mod.Observer = .{},
+    observer: observer_mod.Observer = observer_mod.noop,
     /// When set, `Engine` owns a `DedupRegistry` for `relayIngestChunk`-style helpers.
     enable_cross_session_dedup: bool = false,
 };
@@ -75,6 +75,7 @@ pub const Engine = struct {
         errdefer self.allocator.destroy(ch);
         ch.* = try ChannelRs.init(self.allocator, self, key, cfg);
         try self.channels.put(self.allocator, key, ch);
+        self.config.observer.channelAttached(key, null);
         return ch;
     }
 

--- a/src/broadcast/observer.zig
+++ b/src/broadcast/observer.zig
@@ -1,3 +1,227 @@
-//! Optional hooks aligned with ethp2p `broadcast/observer` (placeholder for gossip integration).
+//! Broadcast-system event observer, aligned with ethp2p
+//! [`broadcast/observer.go`](https://github.com/ethp2p/ethp2p/blob/main/broadcast/observer.go).
+//!
+//! Zig has no interfaces, so `Observer` is type-erased (a `ptr` + `vtable`
+//! pair, like `std.mem.Allocator`); `noop` is the do-nothing default used by
+//! `EngineConfig`. The full 15-callback surface mirrors the Go interface for
+//! forward compatibility. Emission is wired at the sites that exist in the Zig
+//! port today — channel attach, session start/decode, chunk receive, peer
+//! subscribe/unsubscribe. The remaining callbacks (`onPeerHandshook`/`Gone`,
+//! `onSessionDisposed`, `onChunkSent`/`Error`, `onRoutingUpdate`,
+//! `onPreambleOpened`, `onStrategyProgress`) are emitted as their subsystems
+//! land (engine peer tracking; session disposal, #62; strategy hooks).
 
-pub const Observer = struct {};
+const std = @import("std");
+const broadcast_types = @import("../layer/broadcast_types.zig");
+
+pub const Verdict = broadcast_types.Verdict;
+pub const SessionRole = broadcast_types.SessionRole;
+
+pub const Observer = struct {
+    ptr: *anyopaque,
+    vtable: *const VTable,
+
+    pub const VTable = struct {
+        onChannelAttached: *const fn (ctx: *anyopaque, channel_id: []const u8, err: ?anyerror) void,
+        onChannelDropped: *const fn (ctx: *anyopaque, channel_id: []const u8) void,
+        onPeerHandshook: *const fn (ctx: *anyopaque, peer_id: []const u8, version: u32, channels: []const []const u8) void,
+        onPeerSubscribed: *const fn (ctx: *anyopaque, peer_id: []const u8, channel_id: []const u8) void,
+        onPeerUnsubscribed: *const fn (ctx: *anyopaque, peer_id: []const u8, channel_id: []const u8) void,
+        onPeerGone: *const fn (ctx: *anyopaque, peer_id: []const u8) void,
+        onSessionStarted: *const fn (ctx: *anyopaque, channel_id: []const u8, message_id: []const u8, role: SessionRole) void,
+        onSessionDecoded: *const fn (ctx: *anyopaque, channel_id: []const u8, message_id: []const u8, latency_us: i64) void,
+        onSessionDisposed: *const fn (ctx: *anyopaque, channel_id: []const u8, message_id: []const u8, reason: []const u8) void,
+        onChunkSent: *const fn (ctx: *anyopaque, peer_id: []const u8, channel_id: []const u8, message_id: []const u8, bytes_sent: usize) void,
+        onChunkRcvd: *const fn (ctx: *anyopaque, peer_id: []const u8, channel_id: []const u8, message_id: []const u8, verdict: Verdict) void,
+        onChunkError: *const fn (ctx: *anyopaque, channel_id: []const u8, message_id: []const u8, err: anyerror) void,
+        onRoutingUpdate: *const fn (ctx: *anyopaque, peer_id: []const u8, channel_id: []const u8, message_id: []const u8) void,
+        onPreambleOpened: *const fn (ctx: *anyopaque, peer_id: []const u8, channel_id: []const u8, message_id: []const u8) void,
+        onStrategyProgress: *const fn (ctx: *anyopaque, channel_id: []const u8, message_id: []const u8, chunks_have: usize, chunks_need: usize) void,
+    };
+
+    // Channel lifecycle
+    pub fn channelAttached(self: Observer, channel_id: []const u8, err: ?anyerror) void {
+        self.vtable.onChannelAttached(self.ptr, channel_id, err);
+    }
+    pub fn channelDropped(self: Observer, channel_id: []const u8) void {
+        self.vtable.onChannelDropped(self.ptr, channel_id);
+    }
+
+    // Peer lifecycle
+    pub fn peerHandshook(self: Observer, peer_id: []const u8, version: u32, channels: []const []const u8) void {
+        self.vtable.onPeerHandshook(self.ptr, peer_id, version, channels);
+    }
+    pub fn peerSubscribed(self: Observer, peer_id: []const u8, channel_id: []const u8) void {
+        self.vtable.onPeerSubscribed(self.ptr, peer_id, channel_id);
+    }
+    pub fn peerUnsubscribed(self: Observer, peer_id: []const u8, channel_id: []const u8) void {
+        self.vtable.onPeerUnsubscribed(self.ptr, peer_id, channel_id);
+    }
+    pub fn peerGone(self: Observer, peer_id: []const u8) void {
+        self.vtable.onPeerGone(self.ptr, peer_id);
+    }
+
+    // Session lifecycle
+    pub fn sessionStarted(self: Observer, channel_id: []const u8, message_id: []const u8, role: SessionRole) void {
+        self.vtable.onSessionStarted(self.ptr, channel_id, message_id, role);
+    }
+    pub fn sessionDecoded(self: Observer, channel_id: []const u8, message_id: []const u8, latency_us: i64) void {
+        self.vtable.onSessionDecoded(self.ptr, channel_id, message_id, latency_us);
+    }
+    pub fn sessionDisposed(self: Observer, channel_id: []const u8, message_id: []const u8, reason: []const u8) void {
+        self.vtable.onSessionDisposed(self.ptr, channel_id, message_id, reason);
+    }
+
+    // Chunk events
+    pub fn chunkSent(self: Observer, peer_id: []const u8, channel_id: []const u8, message_id: []const u8, bytes_sent: usize) void {
+        self.vtable.onChunkSent(self.ptr, peer_id, channel_id, message_id, bytes_sent);
+    }
+    pub fn chunkRcvd(self: Observer, peer_id: []const u8, channel_id: []const u8, message_id: []const u8, verdict: Verdict) void {
+        self.vtable.onChunkRcvd(self.ptr, peer_id, channel_id, message_id, verdict);
+    }
+    pub fn chunkError(self: Observer, channel_id: []const u8, message_id: []const u8, err: anyerror) void {
+        self.vtable.onChunkError(self.ptr, channel_id, message_id, err);
+    }
+
+    // Routing and strategy progress
+    pub fn routingUpdate(self: Observer, peer_id: []const u8, channel_id: []const u8, message_id: []const u8) void {
+        self.vtable.onRoutingUpdate(self.ptr, peer_id, channel_id, message_id);
+    }
+    pub fn preambleOpened(self: Observer, peer_id: []const u8, channel_id: []const u8, message_id: []const u8) void {
+        self.vtable.onPreambleOpened(self.ptr, peer_id, channel_id, message_id);
+    }
+    pub fn strategyProgress(self: Observer, channel_id: []const u8, message_id: []const u8, chunks_have: usize, chunks_need: usize) void {
+        self.vtable.onStrategyProgress(self.ptr, channel_id, message_id, chunks_have, chunks_need);
+    }
+};
+
+// --- NoOpObserver (ethp2p `NoOpObserver`) -----------------------------------
+
+const noop_impl = struct {
+    fn channelAttached(_: *anyopaque, _: []const u8, _: ?anyerror) void {}
+    fn channelDropped(_: *anyopaque, _: []const u8) void {}
+    fn peerHandshook(_: *anyopaque, _: []const u8, _: u32, _: []const []const u8) void {}
+    fn peerSubscribed(_: *anyopaque, _: []const u8, _: []const u8) void {}
+    fn peerUnsubscribed(_: *anyopaque, _: []const u8, _: []const u8) void {}
+    fn peerGone(_: *anyopaque, _: []const u8) void {}
+    fn sessionStarted(_: *anyopaque, _: []const u8, _: []const u8, _: SessionRole) void {}
+    fn sessionDecoded(_: *anyopaque, _: []const u8, _: []const u8, _: i64) void {}
+    fn sessionDisposed(_: *anyopaque, _: []const u8, _: []const u8, _: []const u8) void {}
+    fn chunkSent(_: *anyopaque, _: []const u8, _: []const u8, _: []const u8, _: usize) void {}
+    fn chunkRcvd(_: *anyopaque, _: []const u8, _: []const u8, _: []const u8, _: Verdict) void {}
+    fn chunkError(_: *anyopaque, _: []const u8, _: []const u8, _: anyerror) void {}
+    fn routingUpdate(_: *anyopaque, _: []const u8, _: []const u8, _: []const u8) void {}
+    fn preambleOpened(_: *anyopaque, _: []const u8, _: []const u8, _: []const u8) void {}
+    fn strategyProgress(_: *anyopaque, _: []const u8, _: []const u8, _: usize, _: usize) void {}
+};
+
+const noop_vtable: Observer.VTable = .{
+    .onChannelAttached = noop_impl.channelAttached,
+    .onChannelDropped = noop_impl.channelDropped,
+    .onPeerHandshook = noop_impl.peerHandshook,
+    .onPeerSubscribed = noop_impl.peerSubscribed,
+    .onPeerUnsubscribed = noop_impl.peerUnsubscribed,
+    .onPeerGone = noop_impl.peerGone,
+    .onSessionStarted = noop_impl.sessionStarted,
+    .onSessionDecoded = noop_impl.sessionDecoded,
+    .onSessionDisposed = noop_impl.sessionDisposed,
+    .onChunkSent = noop_impl.chunkSent,
+    .onChunkRcvd = noop_impl.chunkRcvd,
+    .onChunkError = noop_impl.chunkError,
+    .onRoutingUpdate = noop_impl.routingUpdate,
+    .onPreambleOpened = noop_impl.preambleOpened,
+    .onStrategyProgress = noop_impl.strategyProgress,
+};
+
+/// The default do-nothing observer.
+pub const noop: Observer = .{ .ptr = undefined, .vtable = &noop_vtable };
+
+// --- Tests ------------------------------------------------------------------
+
+const testing = std.testing;
+
+/// A test observer that counts each callback and records the last session role.
+pub const Recording = struct {
+    session_started: usize = 0,
+    session_decoded: usize = 0,
+    chunk_rcvd: usize = 0,
+    peer_subscribed: usize = 0,
+    peer_unsubscribed: usize = 0,
+    channel_attached: usize = 0,
+    last_role: ?SessionRole = null,
+    last_verdict: ?Verdict = null,
+
+    pub fn observer(self: *Recording) Observer {
+        return .{ .ptr = self, .vtable = &vtable };
+    }
+
+    const vtable: Observer.VTable = .{
+        .onChannelAttached = onChannelAttached,
+        .onChannelDropped = noop_impl.channelDropped,
+        .onPeerHandshook = noop_impl.peerHandshook,
+        .onPeerSubscribed = onPeerSubscribed,
+        .onPeerUnsubscribed = onPeerUnsubscribed,
+        .onPeerGone = noop_impl.peerGone,
+        .onSessionStarted = onSessionStarted,
+        .onSessionDecoded = onSessionDecoded,
+        .onSessionDisposed = noop_impl.sessionDisposed,
+        .onChunkSent = noop_impl.chunkSent,
+        .onChunkRcvd = onChunkRcvd,
+        .onChunkError = noop_impl.chunkError,
+        .onRoutingUpdate = noop_impl.routingUpdate,
+        .onPreambleOpened = noop_impl.preambleOpened,
+        .onStrategyProgress = noop_impl.strategyProgress,
+    };
+
+    fn onChannelAttached(ctx: *anyopaque, _: []const u8, _: ?anyerror) void {
+        cast(ctx).channel_attached += 1;
+    }
+    fn onPeerSubscribed(ctx: *anyopaque, _: []const u8, _: []const u8) void {
+        cast(ctx).peer_subscribed += 1;
+    }
+    fn onPeerUnsubscribed(ctx: *anyopaque, _: []const u8, _: []const u8) void {
+        cast(ctx).peer_unsubscribed += 1;
+    }
+    fn onSessionStarted(ctx: *anyopaque, _: []const u8, _: []const u8, role: SessionRole) void {
+        const self = cast(ctx);
+        self.session_started += 1;
+        self.last_role = role;
+    }
+    fn onSessionDecoded(ctx: *anyopaque, _: []const u8, _: []const u8, _: i64) void {
+        cast(ctx).session_decoded += 1;
+    }
+    fn onChunkRcvd(ctx: *anyopaque, _: []const u8, _: []const u8, _: []const u8, verdict: Verdict) void {
+        const self = cast(ctx);
+        self.chunk_rcvd += 1;
+        self.last_verdict = verdict;
+    }
+
+    fn cast(ctx: *anyopaque) *Recording {
+        return @ptrCast(@alignCast(ctx));
+    }
+};
+
+test "noop observer dispatches without effect" {
+    const o = noop;
+    o.channelAttached("ch", null);
+    o.sessionStarted("ch", "m", .origin);
+    o.chunkRcvd("p", "ch", "m", .accepted);
+}
+
+test "recording observer captures dispatched events" {
+    var rec: Recording = .{};
+    const o = rec.observer();
+    o.channelAttached("ch", null);
+    o.sessionStarted("ch", "m", .relay);
+    o.sessionDecoded("ch", "m", 1234);
+    o.chunkRcvd("p", "ch", "m", .redundant);
+    o.peerSubscribed("p", "ch");
+
+    try testing.expectEqual(@as(usize, 1), rec.channel_attached);
+    try testing.expectEqual(@as(usize, 1), rec.session_started);
+    try testing.expectEqual(SessionRole.relay, rec.last_role.?);
+    try testing.expectEqual(@as(usize, 1), rec.session_decoded);
+    try testing.expectEqual(@as(usize, 1), rec.chunk_rcvd);
+    try testing.expectEqual(Verdict.redundant, rec.last_verdict.?);
+    try testing.expectEqual(@as(usize, 1), rec.peer_subscribed);
+}

--- a/src/layer/broadcast_types.zig
+++ b/src/layer/broadcast_types.zig
@@ -6,6 +6,13 @@ pub const ChunkHandle = u64;
 
 pub const protocol_v1: u32 = 1;
 
+/// Distinguishes origin sessions (the publisher) from relay sessions (nodes
+/// forwarding chunks they received from others). Mirrors ethp2p `SessionRole`.
+pub const SessionRole = enum(u8) {
+    origin = 0,
+    relay = 1,
+};
+
 pub const Verdict = enum(u8) {
     accepted = 0,
     redundant = 1,


### PR DESCRIPTION
Closes #58.

Replaces the empty `src/broadcast/observer.zig` placeholder (`pub const Observer = struct {};`) with the full broadcast event **Observer**, aligned with [`broadcast/observer.go`](https://github.com/ethp2p/ethp2p/blob/main/broadcast/observer.go), and adds the **`SessionRole`** enum (`origin`/`relay`) to `layer.broadcast_types`.

## Design
Zig has no interfaces, so `Observer` is type-erased (`ptr` + `vtable`, like `std.mem.Allocator`) with a `noop` default that `EngineConfig` now uses. The full **15-callback** surface mirrors the Go interface for forward compatibility.

## Emission (wired where the events exist today)
| Callback | Site |
|---|---|
| `onChannelAttached` | `Engine.attachChannelRs` |
| `onPeerSubscribed` / `onPeerUnsubscribed` | `ChannelRs.addMember` / `removeMember` |
| `onSessionStarted` | `publish` → `origin`, `attachRelaySession` → `relay` |
| `onSessionDecoded` | `ChannelRs.sessionDecode` |
| `onChunkRcvd` | `relayIngestChunk` / `relayIngestChunkVerified` — one emission per ingest with the resolved verdict |

The remaining callbacks (`onPeerHandshook`/`Gone`, `onSessionDisposed`, `onChunkSent`/`Error`, `onRoutingUpdate`, `onPreambleOpened`, `onStrategyProgress`) match the Go interface and will be emitted as their subsystems land (engine peer tracking; session disposal #62; strategy hooks). This unblocks the `TracingObserver` follow-up for the trace subsystem (#59).

## Tests
- `Recording` test observer verifies vtable dispatch + the no-op path.
- An `Engine` integration test drives publish→decode and asserts channel-attach / peer-subscribe / session-start(origin) / session-decode fire.

## Docs
README implementation-status table now lists the Observer + `SessionRole` and the trace writer; requirements bumped to Zig 0.16.0.

Verified on stock Zig 0.16.0: `zig fmt --check`, `zig build test`, and `zig build test-broadcast` (TSan) pass.