### PR TITLE
chore(varint): adopt shared zig-varint (drop in-tree copy)

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -4,6 +4,7 @@ const Bundle = struct {
     quic_shim: *std.Build.Module,
     zquic: *std.Build.Module,
     compat: *std.Build.Module,
+    zig_varint: *std.Build.Module,
 };
 
 fn addZquicQuicModule(
@@ -13,6 +14,10 @@ fn addZquicQuicModule(
 ) Bundle {
     const zquic_pkg = b.dependency("zquic", .{ .target = target, .optimize = optimize });
     const zquic_mod = zquic_pkg.module("zquic");
+
+    // Shared multiformats/QUIC varint codec (see `src/wire/varint.zig`).
+    const zig_varint_pkg = b.dependency("zig_varint", .{ .target = target, .optimize = optimize });
+    const zig_varint_mod = zig_varint_pkg.module("zig_varint");
 
     // Zig 0.15 → 0.16 std-library compatibility shims (see `src/compat.zig`).
     const compat = b.createModule(.{
@@ -29,12 +34,13 @@ fn addZquicQuicModule(
     quic_shim.addImport("zquic", zquic_mod);
     quic_shim.addImport("compat", compat);
 
-    return .{ .quic_shim = quic_shim, .zquic = zquic_mod, .compat = compat };
+    return .{ .quic_shim = quic_shim, .zquic = zquic_mod, .compat = compat, .zig_varint = zig_varint_mod };
 }
 
 fn wireModule(m: *std.Build.Module, bundle: Bundle) void {
     m.addImport("quic", bundle.quic_shim);
     m.addImport("compat", bundle.compat);
+    m.addImport("zig_varint", bundle.zig_varint);
 }
 
 pub fn build(b: *std.Build) void {

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -18,5 +18,9 @@
             .url = "https://github.com/ch4r10t33r/zquic/archive/refs/tags/v1.7.66.tar.gz",
             .hash = "zquic-1.7.66-2zRc1EBVGACCVRmUoisIxS31Yt0feyFu80VYmgHn74Jw",
         },
+        .zig_varint = .{
+            .url = "https://github.com/ch4r10t33r/zig-varint/archive/refs/tags/v0.1.0.tar.gz",
+            .hash = "zig_varint-0.1.0-JouQHUVXAAAGN-XdMYrVEmYrzJd6zXtI7zk9bPnKYXVK",
+        },
     },
 }

--- a/src/wire/varint.zig
+++ b/src/wire/varint.zig
@@ -1,36 +1,26 @@
+//! Multiformats / protobuf unsigned-varint, re-exported from the shared
+//! [`zig-varint`](https://github.com/ch4r10t33r/zig-varint) codec (issue #57) —
+//! the same package zquic and zig-libp2p already adopted.
+//!
+//! Thin back-compat wrapper so existing call sites keep the in-tree names
+//! (`append`, `decode`, `decodeNonNegativeI32`, `DecodeError`). The cursor
+//! decoders use the *relaxed* variant to preserve the previous in-tree
+//! decoder's tolerance of non-minimal encodings.
+
 const std = @import("std");
+const unsigned = @import("zig_varint").unsigned;
 
-pub fn append(dst: *std.ArrayList(u8), gpa: std.mem.Allocator, value: u64) std.mem.Allocator.Error!void {
-    var v = value;
-    while (v >= 0x80) {
-        try dst.append(gpa, @as(u8, @truncate(v & 0x7f | 0x80)));
-        v >>= 7;
-    }
-    try dst.append(gpa, @as(u8, @truncate(v)));
-}
+pub const DecodeError = unsigned.DecodeError;
 
-pub const DecodeError = error{ Truncated, Overflow, TooLong };
+/// Appends `value` to `dst` as an unsigned-varint.
+pub const append = unsigned.append;
 
-/// Decodes a protobuf varint; returns value and new offset.
+/// Decodes an unsigned-varint at `offset`, advancing it past the value.
 pub fn decode(buf: []const u8, offset: *usize) DecodeError!u64 {
-    var shift: u6 = 0;
-    var result: u64 = 0;
-    var i = offset.*;
-    while (i < buf.len) : (i += 1) {
-        const b = buf[i];
-        if (shift == 63 and b > 1) return error.Overflow;
-        result |= @as(u64, b & 0x7f) << shift;
-        if (b & 0x80 == 0) {
-            offset.* = i + 1;
-            return result;
-        }
-        shift += 7;
-        if (shift > 63) return error.TooLong;
-    }
-    return error.Truncated;
+    return unsigned.decodeAtRelaxed(buf, offset);
 }
 
-/// Decodes a protobuf `int32` for non-negative values (sufficient for RS preamble counts).
+/// Decodes a non-negative protobuf `int32` (sufficient for RS preamble counts).
 pub fn decodeNonNegativeI32(buf: []const u8, offset: *usize) DecodeError!i32 {
     const u = try decode(buf, offset);
     if (u > @as(u64, @intCast(std.math.maxInt(i32)))) return error.Overflow;


### PR DESCRIPTION
Closes #57.

Now that zig-ethp2p is on Zig 0.16 (which `zig-varint` requires), this drops the ~38-line in-tree multiformats unsigned-varint in `src/wire/varint.zig` in favour of a thin re-export of [`zig_varint.unsigned`](https://github.com/ch4r10t33r/zig-varint) — the same shared codec zquic (#126) and zig-libp2p (#98) already adopted.

## Changes
- `build.zig.zon`: `zig fetch --save` of `zig-varint` v0.1.0.
- `build.zig`: `zig_varint` module wired next to `quic` / `compat` (available to all test modules).
- `src/wire/varint.zig`: now re-exports `append`, `decode`, `decodeNonNegativeI32`, `DecodeError` from `zig_varint.unsigned`, keeping the exact call-site API in `wire/rs.zig`, `wire/broadcast.zig`, `sim/gossipsub_rpc_pb.zig`. The cursor decoders map to the **relaxed** variant to preserve the previous decoder's tolerance of non-minimal encodings.

## Verification
Stock Zig 0.16.0: `zig fmt --check`, `zig build test`, and the split roots `test-broadcast` / `test-sim-gossipsub` / `test-sim-rs` all pass — the wire/gossipsub golden-byte tests exercise the shared codec unchanged.