### PR TITLE
transport: expose per-connection ConnectionStats (part of #40)

### DIFF
--- a/src/transport/eth_ec_quic_enabled.zig
+++ b/src/transport/eth_ec_quic_enabled.zig
@@ -161,6 +161,12 @@ pub fn dialImpl(
     const negotiated = quic.getNegotiatedAlpn(conn) orelse return error.MissingAlpn;
     if (!std.mem.eql(u8, negotiated, common.alpn_eth_ec_broadcast)) return error.AlpnMismatch;
 
+    // ConnectionStats (Go transport `ConnectionStats`): a completed handshake
+    // has moved bytes in both directions.
+    const stats = conn.connectionStats() orelse return error.NoConnStats;
+    try std.testing.expect(stats.bytes_sent > 0);
+    try std.testing.expect(stats.bytes_received > 0);
+
     quic.destroy(client_ep, conn);
 }
 

--- a/src/transport/eth_ec_quic_peer.zig
+++ b/src/transport/eth_ec_quic_peer.zig
@@ -171,6 +171,12 @@ pub const PeerConn = struct {
         self.bcast_in = null;
         self.state = .closed;
     }
+
+    /// Total bytes sent / received on the underlying QUIC connection
+    /// (Go transport `ConnectionStats`). Null before the connection exists.
+    pub fn connectionStats(self: *const PeerConn) ?quic.ConnStats {
+        return self.conn.connectionStats();
+    }
 };
 
 /// Convenience re-export of the type accepted by `PeerConn.beginHandshake`.

--- a/src/transport/zquic_quic_shim.zig
+++ b/src/transport/zquic_quic_shim.zig
@@ -136,6 +136,12 @@ pub const QuicEndpoint = struct {
     }
 };
 
+/// Cumulative per-connection byte counters (Go transport `ConnectionStats`).
+pub const ConnStats = struct {
+    bytes_sent: u64,
+    bytes_received: u64,
+};
+
 pub const QuicConnection = struct {
     pub const Stream = struct {
         conn: *QuicConnection,
@@ -224,6 +230,14 @@ pub const QuicConnection = struct {
         const si = self.server_slot orelse return null;
         if (srv.conns[si]) |c| return c;
         return null;
+    }
+
+    /// Total bytes sent / received on this connection (Go transport
+    /// `ConnectionStats`). Returns null before the connection has a state.
+    pub fn connectionStats(self: *const QuicConnection) ?ConnStats {
+        const cs = self.connStatePtrConst() orelse return null;
+        const s = cs.snapshotStats();
+        return .{ .bytes_sent = s.bytes_sent, .bytes_received = s.bytes_recv };
     }
 
     fn removeStreamFromLists(self: *QuicConnection, st: *Stream) void {


### PR DESCRIPTION
Part of #40 (transport features present in the Go reference).

The Go `sim/` transport implements `Conn.ConnectionStats() (bytesSent, bytesReceived)` ([`transport/quic/quic.go`](https://github.com/ethp2p/ethp2p/blob/main/transport/quic/quic.go)). zquic already tracks these per connection and exposes them via `io.ConnState.snapshotStats()` — this just surfaces them:

- `zquic_quic_shim.QuicConnection.connectionStats() ?ConnStats` → reads `snapshotStats()`, returns `{ bytes_sent, bytes_received }`.
- `eth_ec_quic_peer.PeerConn.connectionStats() ?quic.ConnStats` → the public accessor.

The `QUIC listen + dial, TLS handshake` test now asserts a completed handshake reports non-zero `bytes_sent` **and** `bytes_received`.

No zquic dependency change (the underlying stats API is already public). `zig build test` + `zig build test-quic` pass on stock 0.16.0.

Remaining #40 items (stream `Reset`/`CancelRead`/`CancelWrite`, datagrams, deadlines) are separate; the stream-reset piece needs a new public zquic API and will follow.