### PR TITLE
deps: bump zquic to v1.7.86 (release v0.1.1)

### DIFF
--- a/build.zig.zon
+++ b/build.zig.zon
@@ -1,6 +1,6 @@
 .{
     .name = .zig_ethp2p,
-    .version = "0.1.0",
+    .version = "0.1.1",
     .fingerprint = 0xbeef30331296c64d,
     .minimum_zig_version = "0.16.0",
     .paths = .{
@@ -15,8 +15,8 @@
     },
     .dependencies = .{
         .zquic = .{
-            .url = "https://github.com/ch4r10t33r/zquic/archive/refs/tags/v1.7.68.tar.gz",
-            .hash = "zquic-1.7.68-2zRc1F2AGAD-NYyDV5d41f0q8CgkJ1bGogPAStoku50k",
+            .url = "https://github.com/ch4r10t33r/zquic/archive/refs/tags/v1.7.86.tar.gz",
+            .hash = "zquic-1.7.86-2zRc1I2dGQAI1M0gg19eycqe5WRZwvwJx97CECAhYreO",
         },
         .zig_varint = .{
             .url = "https://github.com/ch4r10t33r/zig-varint/archive/refs/tags/v0.1.0.tar.gz",


### PR DESCRIPTION
Aligns zquic with the version zig-libp2p / zeam already use so a downstream that depends on **both** zig-ethp2p and zig-libp2p resolves a single zquic instance rather than two versions (1.7.68 + 1.7.86), which otherwise collide on their generated `build_options` module (`error: file exists in modules build_options1 and build_options2`).

No source changes. Verified locally with the 0.16.0 toolchain: full suite 176/176 and `test-quic` 59/59 green on 1.7.86.