### PR TITLE
deps: source zquic from zigstack (release v0.1.2)

### DIFF
--- a/build.zig.zon
+++ b/build.zig.zon
@@ -1,6 +1,6 @@
 .{
     .name = .zig_ethp2p,
-    .version = "0.1.1",
+    .version = "0.1.2",
     .fingerprint = 0xbeef30331296c64d,
     .minimum_zig_version = "0.16.0",
     .paths = .{
@@ -15,7 +15,7 @@
     },
     .dependencies = .{
         .zquic = .{
-            .url = "https://github.com/ch4r10t33r/zquic/archive/refs/tags/v1.7.86.tar.gz",
+            .url = "https://github.com/zigstack/zquic/archive/refs/tags/v1.7.86.tar.gz",
             .hash = "zquic-1.7.86-2zRc1I2dGQAI1M0gg19eycqe5WRZwvwJx97CECAhYreO",
         },
         .zig_varint = .{


### PR DESCRIPTION
Points the zquic dependency at `github.com/zigstack/zquic` — the canonical org home — matching the **exact URL + hash** that zig-libp2p uses.

Zig deduplicates a diamond dependency only when every consumer pins the identical URL+hash. A downstream (zeam) that depends on both zig-ethp2p and zig-libp2p was getting two separate zquic module instances (`error: file exists in modules 'zquic' and 'zquic0'`) because the two pinned zquic via different org URLs (zigstack vs ch4r10t33r) despite the same content hash. Sharing the zigstack URL lets them resolve to one module (the same way `zig_varint` already dedupes).

Same content hash as before — no source changes.