### PR TITLE
build: forward -Dshadow to zquic so downstreams dedupe it (release v0.1.3)

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -11,8 +11,14 @@ fn addZquicQuicModule(
     b: *std.Build,
     target: std.Build.ResolvedTarget,
     optimize: std.builtin.OptimizeMode,
+    shadow: bool,
 ) Bundle {
-    const zquic_pkg = b.dependency("zquic", .{ .target = target, .optimize = optimize });
+    // Forward `.shadow` to zquic so this instantiation's option set matches the
+    // one zig-libp2p passes (`b.dependency("zquic", .{..., .shadow })`). Zig
+    // keys dependency deduplication on the option set, so an identical set lets
+    // a downstream that pulls both zig-ethp2p and zig-libp2p resolve a single
+    // shared zquic module instead of two colliding ones.
+    const zquic_pkg = b.dependency("zquic", .{ .target = target, .optimize = optimize, .shadow = shadow });
     const zquic_mod = zquic_pkg.module("zquic");
 
     // Shared multiformats/QUIC varint codec (see `src/wire/varint.zig`).
@@ -47,11 +53,16 @@ pub fn build(b: *std.Build) void {
     const target = b.standardTargetOptions(.{});
     const optimize = b.standardOptimizeOption(.{});
 
+    // Forwarded verbatim to the zquic dependency (mirrors zig-libp2p's
+    // `-Dshadow`); keep the option name/default identical so both instantiate
+    // zquic with the same option set and Zig deduplicates it to one module.
+    const shadow = b.option(bool, "shadow", "Forward -Dshadow to the zquic dependency (Shadow simulator build)") orelse false;
+
     if (target.result.os.tag == .windows) {
         std.debug.panic("zig-ethp2p does not support Windows targets (zquic QUIC stack is tested on Unix).", .{});
     }
 
-    const bundle = addZquicQuicModule(b, target, optimize);
+    const bundle = addZquicQuicModule(b, target, optimize, shadow);
 
     const mod = b.addModule("zig_ethp2p", .{
         .root_source_file = b.path("src/root.zig"),
@@ -91,7 +102,7 @@ pub fn build(b: *std.Build) void {
     const ci_opt: std.builtin.OptimizeMode = .Debug;
     const ci_tsan = true;
 
-    const bundle_ci = addZquicQuicModule(b, ci_target, ci_opt);
+    const bundle_ci = addZquicQuicModule(b, ci_target, ci_opt, shadow);
 
     const broadcast_tests_mod = b.createModule(.{
         .root_source_file = b.path("src/ci_root_broadcast.zig"),

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -1,6 +1,6 @@
 .{
     .name = .zig_ethp2p,
-    .version = "0.1.2",
+    .version = "0.1.3",
     .fingerprint = 0xbeef30331296c64d,
     .minimum_zig_version = "0.16.0",
     .paths = .{


### PR DESCRIPTION
## Problem

A downstream that depends on **both** zig-ethp2p and zig-libp2p (e.g. zeam) failed to link with:

```
error: file exists in modules 'zquic' and 'zquic0'
```

Zig keys dependency **deduplication on the option set** passed to `b.dependency`. zig-libp2p instantiates zquic as `b.dependency("zquic", .{ .target, .optimize, .shadow })`, whereas this package passed only `.{ .target, .optimize }`. The differing option sets produced two distinct zquic module instances that collide when linked into one binary. (Matching only the URL/hash was not enough — the option set must match too.)

## Fix

Add a `-Dshadow` build option (default `false`, identical name/default to zig-libp2p) and forward it to the zquic dependency, so both parents instantiate zquic with the same option set and Zig resolves a single shared module.

No source changes. Verified locally: zig-ethp2p suite stays green, and a downstream zeam build that pulls both zig-ethp2p and zig-libp2p now links a single zquic and builds cleanly.